### PR TITLE
replace velodyne interpolate to distortion filter

### DIFF
--- a/aip_x1_launch/launch/velodyne_node_container.launch.py
+++ b/aip_x1_launch/launch/velodyne_node_container.launch.py
@@ -106,13 +106,13 @@ def launch_setup(context, *args, **kwargs):
 
     nodes.append(
         ComposableNode(
-            package="velodyne_pointcloud",
-            plugin="velodyne_pointcloud::Interpolate",
-            name="velodyne_interpolate_node",
+            package="pointcloud_preprocessor",
+            plugin="pointcloud_preprocessor::DistortionCorrectorComponent",
+            name="distortion_corrector_node",
             remappings=[
-                ("velodyne_points_ex", "self_cropped/pointcloud_ex"),
-                ("velodyne_points_interpolate", "rectified/pointcloud"),
-                ("velodyne_points_interpolate_ex", "rectified/pointcloud_ex"),
+                ("~/input/pointcloud", "self_cropped/pointcloud_ex"),
+                ("~/input/velocity_report", "/vehicle/status/velocity_report"),
+                ("~/output/pointcloud", "rectified/pointcloud_ex"),
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )

--- a/common_sensor_launch/launch/velodyne_node_container.launch.py
+++ b/common_sensor_launch/launch/velodyne_node_container.launch.py
@@ -135,13 +135,13 @@ def launch_setup(context, *args, **kwargs):
 
     nodes.append(
         ComposableNode(
-            package="velodyne_pointcloud",
-            plugin="velodyne_pointcloud::Interpolate",
-            name="velodyne_interpolate_node",
+            package="pointcloud_preprocessor",
+            plugin="pointcloud_preprocessor::DistortionCorrectorComponent",
+            name="distortion_corrector_node",
             remappings=[
-                ("velodyne_points_ex", "mirror_cropped/pointcloud_ex"),
-                ("velodyne_points_interpolate", "rectified/pointcloud"),
-                ("velodyne_points_interpolate_ex", "rectified/pointcloud_ex"),
+                ("~/input/pointcloud", "mirror_cropped/pointcloud_ex"),
+                ("~/input/velocity_report", "/vehicle/status/velocity_report"),
+                ("~/output/pointcloud", "rectified/pointcloud_ex"),
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )


### PR DESCRIPTION
I replaced `velodyne_interpolate_node` to `distortion_filter_node` in `common_sensor_launch/launch/velodyne_node_container.launch.py` .