### PR TITLE
Add output screen to livox driver node (#249)

### DIFF
--- a/common_sensor_launch/launch/new_livox_horizon.launch.py
+++ b/common_sensor_launch/launch/new_livox_horizon.launch.py
@@ -87,6 +87,7 @@ def launch_setup(context, *args, **kwargs):
         ],
         parameters=[params],
         condition=IfCondition(LaunchConfiguration("launch_driver")),
+        output='screen',
     )
 
     container = ComposableNodeContainer(


### PR DESCRIPTION
https://github.com/tier4/autoware_launcher.eva/pull/253 sync用です。
new_livox_horizon.launch.pyはaip_launcher側に移動したため、同じ修正をこちらで行いました。