### PR TITLE
chore: sync sync-files.yaml

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -16,3 +16,4 @@
   files:
     - source: .github/workflows/build-and-test.yaml
     - source: .github/workflows/build-and-test-differential.yaml
+    - source: .github/workflows/sync-files.yaml


### PR DESCRIPTION
It's still old.
https://github.com/tier4/aip_launcher/blob/9fd28a04ddf5dd4d55f18ce3a49c19344dce277d/.github/workflows/sync-files.yaml