### PR TITLE
chore: disable LiDAR dummy diag

### DIFF
--- a/aip_x2_launch/launch/dummy_diag_publisher/sensing.launch.xml
+++ b/aip_x2_launch/launch/dummy_diag_publisher/sensing.launch.xml
@@ -1,6 +1,6 @@
 <launch>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/dummy_diag_publisher/gnss.launch.xml"/>
-  <include file="$(find-pkg-share aip_x2_launch)/launch/dummy_diag_publisher/lidar.launch.xml"/>
+  <!-- <include file="$(find-pkg-share aip_x2_launch)/launch/dummy_diag_publisher/lidar.launch.xml"/> -->
 
 </launch>


### PR DESCRIPTION
Temporarily disable LiDAR's dummy diagnostics for AIP X2 until it is put into practice