### PR TITLE
fix(gnss launch): avoid failing to load params in humble

### DIFF
--- a/aip_x1_launch/launch/gnss.launch.xml
+++ b/aip_x1_launch/launch/gnss.launch.xml
@@ -10,7 +10,10 @@
     <!-- Ublox Driver -->
     <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="1.0">
       <remap from="~/fix" to="~/nav_sat_fix" />
+      <!-- NOTE: load 2 file paths to work in both galactic and humble -->
+      <!-- The first one will be deleted after migration to humble has done -->
       <param from="$(find-pkg-share ublox_gps)/c94_f9p_rover.yaml"/>
+      <param from="$(find-pkg-share ublox_gps)/config/c94_f9p_rover.yaml"/>
     </node>
 
     <!-- NavSatFix to MGRS Pose -->

--- a/aip_x2_launch/launch/gnss.launch.xml
+++ b/aip_x2_launch/launch/gnss.launch.xml
@@ -9,7 +9,10 @@
     <!-- Ublox Driver -->
     <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="1.0">
       <remap from="~/fix" to="~/nav_sat_fix" />
+      <!-- NOTE: load 2 file paths to work in both galactic and humble -->
+      <!-- The first one will be deleted after migration to humble has done -->
       <param from="$(find-pkg-share ublox_gps)/c94_f9p_rover.yaml"/>
+      <param from="$(find-pkg-share ublox_gps)/config/c94_f9p_rover.yaml"/>
     </node>
 
     <!-- NavSatFix to MGRS Pose -->

--- a/aip_xx1_launch/launch/gnss.launch.xml
+++ b/aip_xx1_launch/launch/gnss.launch.xml
@@ -17,7 +17,10 @@
     <group if="$(eval &quot;'$(var gnss_receiver)'=='ublox'&quot;)">
       <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="1.0">
         <remap from="~/fix" to="~/nav_sat_fix" />
+        <!-- NOTE: load 2 file paths to work in both galactic and humble -->
+        <!-- The first one will be deleted after migration to humble has done -->
         <param from="$(find-pkg-share ublox_gps)/c94_f9p_rover.yaml"/>
+        <param from="$(find-pkg-share ublox_gps)/config/c94_f9p_rover.yaml"/>
       </node>
     </group>
 


### PR DESCRIPTION
Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description
The place of config files were changed in humble, so added param for humble.
I confirmed this works in both galactic and humble.

This line will be removed after the migration to humble has done.
```
<param from="$(find-pkg-share ublox_gps)/c94_f9p_rover.yaml"/>
```

## Related link
(TIER IV INTERNAL LINK)
https://star4.slack.com/archives/G01RFJTHT0E/p1656319584840089