### PR TITLE
feat: change max_range of side lidar

### DIFF
--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -13,6 +13,7 @@
     <group>
       <push-ros-namespace namespace="top"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLS128.launch.xml">
+        <arg name="max_range" default="250.0" />
         <arg name="sensor_frame" value="velodyne_top" />
         <arg name="device_ip" value="192.168.1.201"/>
         <arg name="port" value="2368"/>
@@ -25,6 +26,7 @@
     <group>
       <push-ros-namespace namespace="left"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
+        <arg name="max_range" default="15.0" />
         <arg name="sensor_frame" value="velodyne_left" />
         <arg name="device_ip" value="192.168.1.202"/>
         <arg name="port" value="2369"/>
@@ -37,6 +39,7 @@
     <group>
       <push-ros-namespace namespace="right"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
+        <arg name="max_range" default="15.0" />
         <arg name="sensor_frame" value="velodyne_right" />
         <arg name="device_ip" value="192.168.1.203"/>
         <arg name="port" value="2370"/>

--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -52,6 +52,7 @@
     <group>
       <push-ros-namespace namespace="rear"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
+        <arg name="max_range" default="130.0" />
         <arg name="sensor_frame" value="velodyne_rear" />
         <arg name="device_ip" value="192.168.1.204"/>
         <arg name="port" value="2371"/>

--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -52,7 +52,7 @@
     <group>
       <push-ros-namespace namespace="rear"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
-        <arg name="max_range" value="130.0" />
+        <arg name="max_range" value="15.0" />
         <arg name="sensor_frame" value="velodyne_rear" />
         <arg name="device_ip" value="192.168.1.204"/>
         <arg name="port" value="2371"/>

--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -13,7 +13,7 @@
     <group>
       <push-ros-namespace namespace="top"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLS128.launch.xml">
-        <arg name="max_range" default="250.0" />
+        <arg name="max_range" value="250.0" />
         <arg name="sensor_frame" value="velodyne_top" />
         <arg name="device_ip" value="192.168.1.201"/>
         <arg name="port" value="2368"/>
@@ -26,7 +26,7 @@
     <group>
       <push-ros-namespace namespace="left"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
-        <arg name="max_range" default="15.0" />
+        <arg name="max_range" value="15.0" />
         <arg name="sensor_frame" value="velodyne_left" />
         <arg name="device_ip" value="192.168.1.202"/>
         <arg name="port" value="2369"/>
@@ -39,7 +39,7 @@
     <group>
       <push-ros-namespace namespace="right"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
-        <arg name="max_range" default="15.0" />
+        <arg name="max_range" value="15.0" />
         <arg name="sensor_frame" value="velodyne_right" />
         <arg name="device_ip" value="192.168.1.203"/>
         <arg name="port" value="2370"/>
@@ -52,7 +52,7 @@
     <group>
       <push-ros-namespace namespace="rear"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
-        <arg name="max_range" default="130.0" />
+        <arg name="max_range" value="130.0" />
         <arg name="sensor_frame" value="velodyne_rear" />
         <arg name="device_ip" value="192.168.1.204"/>
         <arg name="port" value="2371"/>


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Change max_range of side lidars (left/right) to 15 meters from default (130 meters).

## Background
The Velodynes' pointclouds are distorted, so if we use distant pointclouds,  there will be a gap when concatenated with top Velodyne. This leads to misrecognition of obstacle-segmented pointclouds and affects vehicle control. 
Therefore, we decided to use only the nearby pointclouds of side Velodynes.

## Review Procedure
ros2 param dump --print /sensing/lidar/top/velodyne_driver
ros2 param dump --print /sensing/lidar/left/velodyne_driver
ros2 param dump --print /sensing/lidar/right/velodyne_driver
