### PR TITLE
feat(aip_xx1_launch): change respawn delay from 1.0s to 10.0s

### DIFF
--- a/aip_xx1_launch/launch/gnss.launch.xml
+++ b/aip_xx1_launch/launch/gnss.launch.xml
@@ -15,7 +15,7 @@
 
     <!-- Ublox Driver -->
     <group if="$(eval &quot;'$(var gnss_receiver)'=='ublox'&quot;)">
-      <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="1.0">
+      <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="10.0">
         <remap from="~/fix" to="~/nav_sat_fix" />
         <!-- NOTE: load 2 file paths to work in both galactic and humble -->
         <!-- The first one will be deleted after migration to humble has done -->

--- a/aip_xx1_launch/launch/imu.launch.xml
+++ b/aip_xx1_launch/launch/imu.launch.xml
@@ -7,7 +7,7 @@
 
     <group>
       <push-ros-namespace namespace="tamagawa"/>
-      <node pkg="tamagawa_imu_driver" name="tag_serial_driver" exec="tag_serial_driver" if="$(var launch_driver)" respawn="true" respawn_delay="1.0">
+      <node pkg="tamagawa_imu_driver" name="tag_serial_driver" exec="tag_serial_driver" if="$(var launch_driver)" respawn="true" respawn_delay="10.0">
         <remap from="imu/data_raw" to="imu_raw" />
         <param name="port" value="/dev/imu" />
         <param name="imu_frame_id" value="tamagawa/imu_link" />


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

Currently, the respawn settings are given to imu and ublox drivers for a node death due to such as temporal USB disconnection.
However, this can lead to node deaths and respawns at a high frequency, which can negatively affect many other nodes.
To mitigate this effect, we change respawn_delay from 1.0s to 10.0s