### PR TITLE
feat: add sensing topic status diag to xx1

### DIFF
--- a/aip_xx1_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
+++ b/aip_xx1_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
@@ -4,6 +4,16 @@
       type: diagnostic_aggregator/AnalyzerGroup
       path: sensing
       analyzers:
+        node_alive_monitoring:
+          type: diagnostic_aggregator/AnalyzerGroup
+          path: node_alive_monitoring
+          analyzers:
+            topic_status:
+              type: diagnostic_aggregator/GenericAnalyzer
+              path: topic_status
+              contains: [": sensing_topic_status"]
+              timeout: 1.0
+
         lidar:
           type: diagnostic_aggregator/AnalyzerGroup
           path: lidar


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

The node_alive_monitoring check of sensing module was removed  with default settings. I added it.
https://github.com/autowarefoundation/autoware.universe/pull/2311


## Related Links
TIERIV Internal Link: https://star4.slack.com/archives/CTEJP8L4T/p1669108751221979