### PR TITLE
chore(aip_x2_launch): add dummy diag for sensing_topic_status

### DIFF
--- a/aip_x2_launch/launch/dummy_diag_publisher/sensing.launch.xml
+++ b/aip_x2_launch/launch/dummy_diag_publisher/sensing.launch.xml
@@ -3,4 +3,8 @@
   <include file="$(find-pkg-share common_sensor_launch)/launch/dummy_diag_publisher/gnss.launch.xml"/>
   <!-- <include file="$(find-pkg-share aip_x2_launch)/launch/dummy_diag_publisher/lidar.launch.xml"/> -->
 
+  <include file="$(find-pkg-share dummy_diag_publisher)/launch/dummy_diag_publisher_node.launch.xml">
+    <arg name="diag_name" value="sensing_topic_status"/>
+  </include>
+
 </launch>


### PR DESCRIPTION
## PR Type

- Chore

## Related Links

- Jira ticket
  - https://tier4.atlassian.net/browse/T4PB-24275
- related PR
  - https://github.com/tier4/autoware_launch.x2/pull/215

## Description

- planning_simulatorで`sensing_topic_status`のダイアグエラーにより停止することを回避するため、ダミーダイアグを追加しました