### PR TITLE
fix(aip_x*_description): fix xacro deprecated usage

### DIFF
--- a/aip_x1_description/urdf/sensor_kit.xacro
+++ b/aip_x1_description/urdf/sensor_kit.xacro
@@ -17,7 +17,7 @@
     </link>
 
     <!-- sensor -->
-    <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
+    <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
     <!-- lidar -->
     <xacro:VLP-16
       parent="sensor_kit_base_link"

--- a/aip_x1_description/urdf/sensors.xacro
+++ b/aip_x1_description/urdf/sensors.xacro
@@ -3,7 +3,7 @@
 
   <xacro:arg name="config_dir" default="$(find aip_x1_description)/config"/>
   <xacro:include filename="$(find aip_x1_description)/urdf/sensor_kit.xacro"/>
-  <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
+  <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
 
   <!-- sensor kit -->
   <xacro:sensor_kit_macro

--- a/aip_x2_description/urdf/front_unit.xacro
+++ b/aip_x2_description/urdf/front_unit.xacro
@@ -20,7 +20,7 @@
     </link>
 
     <!-- sensor -->
-    <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/front_unit_calibration.yaml')}"/>
+    <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/front_unit_calibration.yaml')}"/>
 
     <!-- BFS7(LR) -->
     <xacro:monocular_camera_macro

--- a/aip_x2_description/urdf/rear_unit.xacro
+++ b/aip_x2_description/urdf/rear_unit.xacro
@@ -20,7 +20,7 @@
     </link>
 
     <!-- sensor -->
-    <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/rear_unit_calibration.yaml')}"/>
+    <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/rear_unit_calibration.yaml')}"/>
 
     <!-- BFS4(R) -->
     <xacro:monocular_camera_macro

--- a/aip_x2_description/urdf/sensors.xacro
+++ b/aip_x2_description/urdf/sensors.xacro
@@ -2,7 +2,7 @@
 <robot name="vehicle" xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:arg name="config_dir" default="$(find aip_x2_description)/config"/>
-  <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
+  <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
 
   <!-- top unit -->
   <xacro:include filename="top_unit.xacro"/>

--- a/aip_x2_description/urdf/top_unit.xacro
+++ b/aip_x2_description/urdf/top_unit.xacro
@@ -21,7 +21,7 @@
     </link>
 
     <!-- sensor -->
-    <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/top_unit_calibration.yaml')}"/>
+    <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/top_unit_calibration.yaml')}"/>
 
     <!-- lidar -->
     <!-- left -->

--- a/aip_xx1_description/urdf/sensor_kit.xacro
+++ b/aip_xx1_description/urdf/sensor_kit.xacro
@@ -23,7 +23,7 @@
     </link>
 
     <!-- sensor -->
-    <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
+    <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensor_kit_calibration.yaml')}"/>
     <!-- lidar -->
     <xacro:VLS-128
       parent="sensor_kit_base_link"

--- a/aip_xx1_description/urdf/sensors.xacro
+++ b/aip_xx1_description/urdf/sensors.xacro
@@ -2,7 +2,7 @@
 <robot name="vehicle" xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:arg name="config_dir" default="$(find aip_xx1_description)/config"/>
-  <xacro:property name="calibration" value="${load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
+  <xacro:property name="calibration" value="${xacro.load_yaml('$(arg config_dir)/sensors_calibration.yaml')}"/>
 
   <!-- sensor kit -->
   <xacro:include filename="sensor_kit.xacro"/>


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

In order to remove the multiple warning messages `warning: Using load_yaml() directly is deprecated. Use xacro.load_yaml() instead.` when launching autoware.