### PR TITLE
chore(gnss launch): remove config loading for galactic

### DIFF
--- a/aip_x1_launch/launch/gnss.launch.xml
+++ b/aip_x1_launch/launch/gnss.launch.xml
@@ -10,9 +10,6 @@
     <!-- Ublox Driver -->
     <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="1.0">
       <remap from="~/fix" to="~/nav_sat_fix" />
-      <!-- NOTE: load 2 file paths to work in both galactic and humble -->
-      <!-- The first one will be deleted after migration to humble has done -->
-      <param from="$(find-pkg-share ublox_gps)/c94_f9p_rover.yaml"/>
       <param from="$(find-pkg-share ublox_gps)/config/c94_f9p_rover.yaml"/>
     </node>
 

--- a/aip_xx1_launch/launch/gnss.launch.xml
+++ b/aip_xx1_launch/launch/gnss.launch.xml
@@ -17,9 +17,6 @@
     <group if="$(eval &quot;'$(var gnss_receiver)'=='ublox'&quot;)">
       <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="10.0">
         <remap from="~/fix" to="~/nav_sat_fix" />
-        <!-- NOTE: load 2 file paths to work in both galactic and humble -->
-        <!-- The first one will be deleted after migration to humble has done -->
-        <param from="$(find-pkg-share ublox_gps)/c94_f9p_rover.yaml"/>
         <param from="$(find-pkg-share ublox_gps)/config/c94_f9p_rover.yaml"/>
       </node>
     </group>


### PR DESCRIPTION
## Description
Since the latest Autoware has migrated to humble, I removed temporary config loading for galactic.

## Related link
- https://github.com/tier4/aip_launcher/pull/71