### PR TITLE
feat(x1): update livox min range to 1.0m

### DIFF
--- a/aip_x1_launch/launch/lidar.launch.xml
+++ b/aip_x1_launch/launch/lidar.launch.xml
@@ -7,6 +7,9 @@
   <arg name="use_pointcloud_container" default="false" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
 
+  <!-- x1 additional setting -->
+  <arg name="livox_min_range" default="1.0" />
+
   <group>
     <push-ros-namespace namespace="lidar"/>
 
@@ -28,6 +31,7 @@
         <include file="$(find-pkg-share aip_x1_launch)/launch/new_livox_horizon.launch.py">
           <arg name="launch_driver" value="$(var launch_driver)" />
           <arg name="lidar_config_file" value="$(find-pkg-share individual_params)/config/default/new_driver_livox_front_right_config.yaml" />
+          <arg name="min_range" value="$(var livox_min_range)" />
         </include>
       </group>
       <group>
@@ -35,6 +39,7 @@
         <include file="$(find-pkg-share aip_x1_launch)/launch/new_livox_horizon.launch.py">
           <arg name="launch_driver" value="$(var launch_driver)" />
           <arg name="lidar_config_file" value="$(find-pkg-share individual_params)/config/default/new_driver_livox_front_center_config.yaml" />
+          <arg name="min_range" value="$(var livox_min_range)" />
 	      </include>
       </group>
       <group>
@@ -42,6 +47,7 @@
         <include file="$(find-pkg-share aip_x1_launch)/launch/new_livox_horizon.launch.py">
           <arg name="launch_driver" value="$(var launch_driver)" />
           <arg name="lidar_config_file" value="$(find-pkg-share individual_params)/config/default/new_driver_livox_front_left_config.yaml" />
+          <arg name="min_range" value="$(var livox_min_range)" />
 	      </include>
       </group>
     </group>

--- a/aip_x1_launch/launch/lidar.launch.xml
+++ b/aip_x1_launch/launch/lidar.launch.xml
@@ -32,21 +32,21 @@
     <group unless="$(var use_dji_driver)">
       <group>
 	      <push-ros-namespace namespace="front_right"/>
-        <include file="$(find-pkg-share common_sensor_launch)/launch/new_livox_horizon.launch.py">
+        <include file="$(find-pkg-share aip_x1_launch)/launch/new_livox_horizon.launch.py">
           <arg name="launch_driver" value="$(var launch_driver)" />
           <arg name="lidar_config_file" value="$(find-pkg-share individual_params)/config/default/new_driver_livox_front_right_config.yaml" />
         </include>
       </group>
       <group>
         <push-ros-namespace namespace="front_center"/>
-        <include file="$(find-pkg-share common_sensor_launch)/launch/new_livox_horizon.launch.py">
+        <include file="$(find-pkg-share aip_x1_launch)/launch/new_livox_horizon.launch.py">
           <arg name="launch_driver" value="$(var launch_driver)" />
           <arg name="lidar_config_file" value="$(find-pkg-share individual_params)/config/default/new_driver_livox_front_center_config.yaml" />
 	      </include>
       </group>
       <group>
         <push-ros-namespace namespace="front_left"/>
-        <include file="$(find-pkg-share common_sensor_launch)/launch/new_livox_horizon.launch.py">
+        <include file="$(find-pkg-share aip_x1_launch)/launch/new_livox_horizon.launch.py">
           <arg name="launch_driver" value="$(var launch_driver)" />
           <arg name="lidar_config_file" value="$(find-pkg-share individual_params)/config/default/new_driver_livox_front_left_config.yaml" />
 	      </include>

--- a/aip_x1_launch/launch/new_livox_horizon.launch.py
+++ b/aip_x1_launch/launch/new_livox_horizon.launch.py
@@ -1,0 +1,124 @@
+# Copyright 2020 Tier IV, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import launch
+from launch.actions import DeclareLaunchArgument
+from launch.actions import OpaqueFunction
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import LoadComposableNodes
+from launch_ros.actions import Node
+from launch_ros.descriptions import ComposableNode
+import yaml
+
+
+def get_livox_tag_filter_component():
+    # livox tag filter
+    livox_tag_filter_component = ComposableNode(
+        package="livox_tag_filter",
+        plugin="livox_tag_filter::LivoxTagFilterNode",
+        name="livox_tag_filter",
+        remappings=[
+            ("input", "livox/lidar"),
+            ("output", "livox/tag_filtered/lidar"),
+        ],
+        parameters=[
+            {
+                "ignore_tags": [1, 2, 20, 21, 22, 23, 24],
+            }
+        ],
+        extra_arguments=[{"use_intra_process_comms": True}],
+    )
+    return livox_tag_filter_component
+
+
+def get_crop_box_min_range_component(context, livox_frame_id):
+    use_tag_filter = IfCondition(LaunchConfiguration("use_tag_filter")).evaluate(context)
+    crop_box_min_range_component = ComposableNode(
+        package="pointcloud_preprocessor",
+        plugin="pointcloud_preprocessor::CropBoxFilterComponent",
+        name="crop_box_filter_min_range",
+        remappings=[
+            ("input", "livox/tag_filtered/lidar" if use_tag_filter else "livox/lidar"),
+            ("output", "min_range_cropped/pointcloud"),
+        ],
+        parameters=[
+            {
+                "input_frame": livox_frame_id,
+                "output_frame": LaunchConfiguration("base_frame"),
+                "min_x": 0.0,
+                "max_x": 1.5,
+                "min_y": -2.0,
+                "max_y": 2.0,
+                "min_z": -2.0,
+                "max_z": 2.0,
+                "negative": True,
+            }
+        ],
+        extra_arguments=[{"use_intra_process_comms": True}],
+    )
+    return crop_box_min_range_component
+
+
+def launch_setup(context, *args, **kwargs):
+    lidar_config_path = LaunchConfiguration("lidar_config_file").perform(context)
+    with open(lidar_config_path, "r") as f:
+        params = yaml.safe_load(f)["/**"]["ros__parameters"]
+
+    livox_driver_node = Node(
+        executable="lidar_ros_driver_node",
+        package="lidar_ros_driver",
+        name="livox_horizon",
+        remappings=[
+            ("livox/cloud", "livox/lidar"),
+            ("livox/imu_packet", "livox/imu"),
+        ],
+        parameters=[params],
+        condition=IfCondition(LaunchConfiguration("launch_driver")),
+        output="screen",
+    )
+
+    container = ComposableNodeContainer(
+        name="livox_horizon",
+        namespace="livox_horizon",
+        package="rclcpp_components",
+        executable="component_container",
+        composable_node_descriptions=[
+            get_crop_box_min_range_component(context, params["frame_id"]),
+        ],
+        output="screen",
+    )
+
+    livox_tag_filter_loader = LoadComposableNodes(
+        composable_node_descriptions=[get_livox_tag_filter_component()],
+        target_container=container,
+        condition=IfCondition(LaunchConfiguration("use_tag_filter")),
+    )
+
+    return [livox_driver_node, container, livox_tag_filter_loader]
+
+
+def generate_launch_description():
+    launch_arguments = []
+
+    def add_launch_arg(name: str, default_value=None):
+        launch_arguments.append(DeclareLaunchArgument(name, default_value=default_value))
+
+    add_launch_arg("launch_driver", "true")
+    add_launch_arg("base_frame", "base_link")
+    add_launch_arg("use_tag_filter", "true")
+    add_launch_arg("lidar_config_file")
+
+    return launch.LaunchDescription(launch_arguments + [OpaqueFunction(function=launch_setup)])

--- a/aip_x1_launch/launch/new_livox_horizon.launch.py
+++ b/aip_x1_launch/launch/new_livox_horizon.launch.py
@@ -59,7 +59,7 @@ def get_crop_box_min_range_component(context, livox_frame_id):
                 "input_frame": livox_frame_id,
                 "output_frame": LaunchConfiguration("base_frame"),
                 "min_x": 0.0,
-                "max_x": 1.5,
+                "max_x": LaunchConfiguration("min_range"),
                 "min_y": -2.0,
                 "max_y": 2.0,
                 "min_z": -2.0,
@@ -120,5 +120,8 @@ def generate_launch_description():
     add_launch_arg("base_frame", "base_link")
     add_launch_arg("use_tag_filter", "true")
     add_launch_arg("lidar_config_file")
+
+    # x1 additional setting
+    add_launch_arg("min_range", "1.5")
 
     return launch.LaunchDescription(launch_arguments + [OpaqueFunction(function=launch_setup)])

--- a/aip_x1_launch/package.xml
+++ b/aip_x1_launch/package.xml
@@ -10,7 +10,6 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>compare_map_segmentation</exec_depend>
   <exec_depend>gnss_poser</exec_depend>
   <exec_depend>pointcloud_preprocessor</exec_depend>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
!!! This PR assumes that the https://github.com/tier4/aip_launcher/pull/104 has been merged. !!!

This PR applies to the close-range version of livox_horizon.
With this PR, the vehicle will be able to see up to a close distance of 1.0[m], which is the limit of the hardware specs of the close range version of livox.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
[T4PB-25423 (TIERIV, INC. INTERNAL LINK)](https://tier4.atlassian.net/browse/T4PB-25423)
https://github.com/tier4/aip_launcher/pull/104
## Tests performed

<!-- Describe how you have tested this PR. -->
Assumptions:
Originally, the min_range crop function was used to remove near-field noise from lidar sensors.
In the case of the livox sensor, there is a feature that sensor noise is detected in front of the actual object.
Especially when driving on a narrow road, sensor noise from obstacles on the left and right of the lane may enter the lane.
In this case, the vehicle may erroneously detect as if there is an obstacle ahead.

Validation:
A running test was conducted on a narrow road with a width of 1.75 [m], which is the worst condition assumed under x1 usage conditions.
We have confirmed that it can pass through obstacles without false detection.

Verification:
After launch, confirm that the settings have been reflected with the following command.
```ros2 param get /sensing/lidar/front_center/crop_box_filter_min_range max_x```
As expected, the result is shown below.
```Double value is: 1.0```
I did the same test on the left and right and got the same results.
## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->
This PR assumes that the https://github.com/tier4/aip_launcher/pull/104 has been merged.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/