### PR TITLE
feat: change concatenate setting and set max range of rear_lidar in xx1

### DIFF
--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -52,7 +52,7 @@
     <group>
       <push-ros-namespace namespace="rear"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
-        <arg name="max_range" value="15.0" />
+        <arg name="max_range" value="1.5" />
         <arg name="sensor_frame" value="velodyne_rear" />
         <arg name="device_ip" value="192.168.1.204"/>
         <arg name="port" value="2371"/>

--- a/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
@@ -38,6 +38,7 @@ def launch_setup(context, *args, **kwargs):
                     "/sensing/lidar/top/outlier_filtered/pointcloud",
                     "/sensing/lidar/left/outlier_filtered/pointcloud",
                     "/sensing/lidar/right/outlier_filtered/pointcloud",
+                    "/sensing/lidar/rear/outlier_filtered/pointcloud",
                 ],
                 "output_frame": LaunchConfiguration("base_frame"),
             }

--- a/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
@@ -36,8 +36,8 @@ def launch_setup(context, *args, **kwargs):
             {
                 "input_topics": [
                     "/sensing/lidar/top/outlier_filtered/pointcloud",
-                    "/sensing/lidar/left/outlier_filtered/pointcloud",
-                    "/sensing/lidar/right/outlier_filtered/pointcloud",
+                    # "/sensing/lidar/left/outlier_filtered/pointcloud",
+                    # "/sensing/lidar/right/outlier_filtered/pointcloud",
                     "/sensing/lidar/rear/outlier_filtered/pointcloud",
                 ],
                 "output_frame": LaunchConfiguration("base_frame"),


### PR DESCRIPTION
In order to use the point cloud by the rear LiDAR for object recognition, we decided to use the point cloud within 1.5m from the following viewpoints.

- The position of the rear lidar is slightly shifted depending on the degree of tightness of the back door, and if it is used as it is, it will lead to errors in ground removal due to calibration deviation. Therefore, We want to use the rear pointcloud within the range that does not include the ground point cloud,
- The mounting position of the rear Lidar is approximately 1.6~1.7m from the ground.
(TierIV Internal: JPNTaxi Vehicle)
https://github.com/tier4/autoware_individual_params.jpntaxi/blob/main/individual_params/config/2/aip_xx1/sensors_calibration.yaml#L26