### PR TITLE
fix: change temperature_status to temperature_monitor

### DIFF
--- a/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -18,5 +18,5 @@
       sensing_topic_status: default
       septentrio_topic_status: default
       concat_status: default
-      temperature_status: default
+      temperature_monitor: default
       emergency_vehicle: default


### PR DESCRIPTION
## Description
Change temperature_status to temperature_monitor to make dummy diag publisher work well.

## Related Links
- https://github.com/tier4/autoware.universe/pull/377
- https://github.com/tier4/autoware_launch.x2/pull/275
