### PR TITLE
ci(pre-commit): upgrade isort version to fix CI failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         args: [-w, -s, -i=4]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/aip_x2_launch/launch/sensing.launch.xml
+++ b/aip_x2_launch/launch/sensing.launch.xml
@@ -40,5 +40,5 @@
     <include file="$(find-pkg-share aip_x2_launch)/launch/topic_state_monitor.launch.py" />
 
   </group>
-  
+
 </launch>


### PR DESCRIPTION
## Description
This fixes pre-commit CI failure.
https://results.pre-commit.ci/run/github/405717191/1682510249.FQJTllpBSzeCODRb05CZ3w

See https://github.com/autowarefoundation/autoware.universe/pull/2777 for details.