### PR TITLE
fix: delete duplicate definition of camera6 and camera7

### DIFF
--- a/aip_xx1_description/urdf/sensor_kit.xacro
+++ b/aip_xx1_description/urdf/sensor_kit.xacro
@@ -78,36 +78,6 @@
     </xacro:VLP-16>
     <!-- camera -->
     <xacro:monocular_camera_macro
-      name="camera7/camera"
-      parent="sensor_kit_base_link"
-      namespace=""
-      x="${calibration['sensor_kit_base_link']['camera7/camera_link']['x']}"
-      y="${calibration['sensor_kit_base_link']['camera7/camera_link']['y']}"
-      z="${calibration['sensor_kit_base_link']['camera7/camera_link']['z']}"
-      roll="${calibration['sensor_kit_base_link']['camera7/camera_link']['roll']}"
-      pitch="${calibration['sensor_kit_base_link']['camera7/camera_link']['pitch']}"
-      yaw="${calibration['sensor_kit_base_link']['camera7/camera_link']['yaw']}"
-      fps="30"
-      width="800"
-      height="400"
-      fov="1.3"
-    />
-    <xacro:monocular_camera_macro
-      name="camera6/camera"
-      parent="sensor_kit_base_link"
-      namespace=""
-      x="${calibration['sensor_kit_base_link']['camera6/camera_link']['x']}"
-      y="${calibration['sensor_kit_base_link']['camera6/camera_link']['y']}"
-      z="${calibration['sensor_kit_base_link']['camera6/camera_link']['z']}"
-      roll="${calibration['sensor_kit_base_link']['camera6/camera_link']['roll']}"
-      pitch="${calibration['sensor_kit_base_link']['camera6/camera_link']['pitch']}"
-      yaw="${calibration['sensor_kit_base_link']['camera6/camera_link']['yaw']}"
-      fps="30"
-      width="800"
-      height="400"
-      fov="1.3"
-    />
-    <xacro:monocular_camera_macro
       name="camera0/camera"
       parent="sensor_kit_base_link"
       namespace=""


### PR DESCRIPTION
https://github.com/tier4/aip_launcher/pull/126
The camera6 and camera7 were already defined in [different places](https://github.com/tier4/aip_launcher/blob/ae34020b2b51af69048e0e91c1c70d3f4831270c/aip_xx1_description/urdf/sensor_kit.xacro#L170-L199), so they were duplicated. 
I deleted it.