### PR TITLE
feat!: rename camera 6 and 7

### DIFF
--- a/aip_xx1_description/config/sensor_kit_calibration.yaml
+++ b/aip_xx1_description/config/sensor_kit_calibration.yaml
@@ -42,29 +42,15 @@ sensor_kit_base_link:
     pitch: -0.01
     yaw: 3.125
   camera6/camera_link:
-    x: 0.396865
-    y: -0.028041
-    z: -0.204267
-    roll: 0.000933
-    pitch: 0.007147
-    yaw: 0.025164
-  camera7/camera_link:
-    x: 0.383094
-    y: 0.020355
-    z: -0.205253
-    roll: 0.011505
-    pitch: -0.017980
-    yaw: 0.034071
-  traffic_light_right_camera/camera_link:
     x: 0.05
-    y: -0.0175
+    y: 0.0175
     z: -0.1
     roll: 0.0
     pitch: 0.0
     yaw: 0.0
-  traffic_light_left_camera/camera_link:
+  camera7/camera_link:
     x: 0.05
-    y: 0.0175
+    y: -0.0175
     z: -0.1
     roll: 0.0
     pitch: 0.0


### PR DESCRIPTION
We should change sensor tf by https://github.com/tier4/autoware_individual_params.jpntaxi/pull/71

- The current camera6 and camera7 is dummy
- traffic light right should be camera 7 and the left should be camera 6.