### PR TITLE
chore: fix gnss diagnostics aggregator config

### DIFF
--- a/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
@@ -47,7 +47,7 @@
                     gnss:
                       type: diagnostic_aggregator/GenericAnalyzer
                       path: gnss
-                      contains: [": gnss"]
+                      startswith: ["gnss"]
                       timeout: 1.0
                 node_alive_monitoring:
                   type: diagnostic_aggregator/AnalyzerGroup


### PR DESCRIPTION
## Description
Fix the gnss diagnostic aggregator config.
Septentrio sends the diag message below. and it couldn't catch up with the current aggregator config. So the PR fix the issue which is not aggregate gnss diag.

```
---
header:
  stamp:
    sec: 1682563874
    nanosec: 67019904
  frame_id: gnss_right_link
status:
- level: "\0"
  name: gnss
  message: Quality Indicators (from 0 for low quality to 10 for high quality, 15 if unknown)
  hardware_id: '3603693'
  values:
  - key: RF Power, Main Antenna
    value: '10'
  - key: GNSS Signals, Main Antenna
    value: '8'
  - key: CPU Headroom
    value: '10'
  - key: RTK Post-Processing
    value: '9'
```

## Related Links
- https://tier4.atlassian.net/browse/RT0-28035