### PR TITLE
chore: add gnss aggregator for dummy_diag

### DIFF
--- a/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
@@ -48,6 +48,7 @@
                       type: diagnostic_aggregator/GenericAnalyzer
                       path: gnss
                       startswith: ["gnss"]
+                      contains: [": gnss"]
                       timeout: 1.0
                 node_alive_monitoring:
                   type: diagnostic_aggregator/AnalyzerGroup


### PR DESCRIPTION
## Description
Fixed the gnss diag with the [PR](https://github.com/tier4/aip_launcher/pull/131). However couldn't care the things that dummy_diag also sends gnss diag. So this PR added an aggregator for the dummy_diag publisher. 

## Related Links
- https://github.com/tier4/aip_launcher/pull/131