### PR TITLE
fix(aip_x2): timeout param

### DIFF
--- a/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
@@ -20,17 +20,17 @@
                       type: diagnostic_aggregator/GenericAnalyzer
                       path: connection
                       contains: [": pandar_connection"]
-                      timeout: 1.0
+                      timeout: 5.0
                     temperature:
                       type: diagnostic_aggregator/GenericAnalyzer
                       path: temperature
                       contains: [": pandar_temperature"]
-                      timeout: 1.0
+                      timeout: 5.0
                     ptp:
                       type: diagnostic_aggregator/GenericAnalyzer
                       path: ptp
                       contains: [": pandar_ptp"]
-                      timeout: 1.0
+                      timeout: 5.0
 
         gnss:
           type: diagnostic_aggregator/AnalyzerGroup


### PR DESCRIPTION
Modify the parameters of diagnostics_aggregator related to pandar_monitor.

The diagnostics of pandar_monitor are output at a frequency of 1.0 Hz, so even if it is functioning normally, it may time out depending on the timing. Therefore, I propose changing it from 1.0 to 5.0.