### PR TITLE
fix: set VLP16 effective angle range in XX1 launcher

### DIFF
--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -28,11 +28,13 @@
     <group>
       <push-ros-namespace namespace="left"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
-        <arg name="max_range" value="15.0" />
+        <arg name="max_range" value="5.0" />
         <arg name="sensor_frame" value="velodyne_left" />
         <arg name="device_ip" value="192.168.1.202"/>
         <arg name="port" value="2369"/>
         <arg name="scan_phase" value="180.0" />
+        <arg name="view_direction" value="0.0" />
+        <arg name="view_width" value="1.9" />
         <arg name="launch_driver" value="$(var launch_driver)" />
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)" />
         <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)" />
@@ -43,11 +45,13 @@
     <group>
       <push-ros-namespace namespace="right"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
-        <arg name="max_range" value="15.0" />
+        <arg name="max_range" value="5.0" />
         <arg name="sensor_frame" value="velodyne_right" />
         <arg name="device_ip" value="192.168.1.203"/>
         <arg name="port" value="2370"/>
         <arg name="scan_phase" value="180.0" />
+        <arg name="view_direction" value="0.0" />
+        <arg name="view_width" value="1.9" />
         <arg name="launch_driver" value="$(var launch_driver)" />
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)" />
         <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)" />
@@ -63,6 +67,8 @@
         <arg name="device_ip" value="192.168.1.204"/>
         <arg name="port" value="2371"/>
         <arg name="scan_phase" value="180.0" />
+        <arg name="view_direction" value="0.0" />
+        <arg name="view_width" value="1.9" />
         <arg name="launch_driver" value="$(var launch_driver)" />
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)" />
         <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)" />


### PR DESCRIPTION
# Description 
This to limit effective angle range for VLP16 lidar for XX1 (left, right, rear) to exclude some kind of noise pointclouds around the edge of each lidar pointcloud as figure. 
![image](https://github.com/tier4/aip_launcher/assets/94814556/01b83ffd-1ee4-4937-b9d1-e96936b81907)

Before changing:
![image](https://github.com/tier4/aip_launcher/assets/94814556/a32c5682-5a30-442e-b4d0-cb5a9f026de8)


After changing:

![image](https://github.com/tier4/aip_launcher/assets/94814556/30adb9bd-83c5-4808-bd9a-dc710580f7a2)
