### PR TITLE
fix(aip_x2): radar_link name

### DIFF
--- a/aip_x2_description/urdf/front_unit.xacro
+++ b/aip_x2_description/urdf/front_unit.xacro
@@ -65,7 +65,7 @@
 
     <!-- radar -->
     <xacro:radar_macro
-      name="front_center/radar"
+      name="front_center/radar_link"
       parent="front_unit_base_link"
       x="${calibration['front_unit_base_link']['front_center/radar_link']['x']}"
       y="${calibration['front_unit_base_link']['front_center/radar_link']['y']}"
@@ -76,7 +76,7 @@
     />
 
     <xacro:radar_macro
-      name="front_left/radar"
+      name="front_left/radar_link"
       parent="front_unit_base_link"
       x="${calibration['front_unit_base_link']['front_left/radar_link']['x']}"
       y="${calibration['front_unit_base_link']['front_left/radar_link']['y']}"
@@ -87,7 +87,7 @@
     />
 
     <xacro:radar_macro
-      name="front_right/radar"
+      name="front_right/radar_link"
       parent="front_unit_base_link"
       x="${calibration['front_unit_base_link']['front_right/radar_link']['x']}"
       y="${calibration['front_unit_base_link']['front_right/radar_link']['y']}"

--- a/aip_x2_description/urdf/rear_unit.xacro
+++ b/aip_x2_description/urdf/rear_unit.xacro
@@ -65,7 +65,7 @@
 
     <!-- radar -->
     <xacro:radar_macro
-      name="rear_center/radar"
+      name="rear_center/radar_link"
       parent="rear_unit_base_link"
       x="${calibration['rear_unit_base_link']['rear_center/radar_link']['x']}"
       y="${calibration['rear_unit_base_link']['rear_center/radar_link']['y']}"
@@ -76,7 +76,7 @@
     />
 
     <xacro:radar_macro
-      name="rear_left/radar"
+      name="rear_left/radar_link"
       parent="rear_unit_base_link"
       x="${calibration['rear_unit_base_link']['rear_left/radar_link']['x']}"
       y="${calibration['rear_unit_base_link']['rear_left/radar_link']['y']}"
@@ -87,7 +87,7 @@
     />
 
     <xacro:radar_macro
-      name="rear_right/radar"
+      name="rear_right/radar_link"
       parent="rear_unit_base_link"
       x="${calibration['rear_unit_base_link']['rear_right/radar_link']['x']}"
       y="${calibration['rear_unit_base_link']['rear_right/radar_link']['y']}"


### PR DESCRIPTION
Fix the name of radar link
  
### Reference Link
- https://github.com/tier4/aip_launcher/blob/tier4/universe/aip_x2_description/urdf/radar.xacro#L12
- https://github.com/tier4/autoware_individual_params.j6_gen1/blob/main/individual_params/config/j6_gen1_01/aip_x2/front_unit_calibration.yaml#L23