### PR TITLE
feat(aip_x2_launch): modify input_offset for lidar concatenation

### DIFF
--- a/aip_x2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x2_launch/launch/pointcloud_preprocessor.launch.py
@@ -44,7 +44,7 @@ def launch_setup(context, *args, **kwargs):
                     "/sensing/lidar/rear_upper/outlier_filtered/pointcloud",
                     "/sensing/lidar/rear_lower/outlier_filtered/pointcloud",
                 ],
-                "input_offset": [0.025, 0.025, 0.025, 0.0, 0.05, 0.05, 0.05, 0.05],
+                "input_offset": [0.025, 0.025, 0.01, 0.0, 0.05, 0.05, 0.05, 0.05],
                 "timeout_sec": 0.075,
                 "output_frame": LaunchConfiguration("base_frame"),
             }


### PR DESCRIPTION
# Background

[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03S84LDJGG/p1685670572633709?thread_ts=1685516277.205259&cid=C03S84LDJGG)

# Test Performed

- Publish timing is correct.

![image](https://github.com/tier4/aip_launcher/assets/58775300/49dfe9b4-1986-4ce9-8552-b8f5c6928c4b)

- Number of pointcloud in `/sensing/lidar/concatenated/pointcloud` is correct.

![image](https://github.com/tier4/aip_launcher/assets/58775300/80eb60e9-8f81-4849-a84b-70806b1b705f)

# Reference

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/~621c20149c3cce006949b60f/pages/2798424064/2023+06+12+concat+offset+x2+BYD+J6#%E5%A4%89%E6%9B%B4%E5%BE%8C)
