### PR TITLE
chore: revert gnss timeout

### DIFF
--- a/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
@@ -49,7 +49,7 @@
                       path: gnss
                       startswith: ["gnss"]
                       contains: [": gnss"]
-                      timeout: 30.0
+                      timeout: 1.0
                 node_alive_monitoring:
                   type: diagnostic_aggregator/AnalyzerGroup
                   path: node_alive_monitoring
@@ -58,7 +58,7 @@
                       type: diagnostic_aggregator/GenericAnalyzer
                       path: topic_status
                       contains: [": septentrio_topic_status"]
-                      timeout: 30.0
+                      timeout: 1.0
 
         imu:
           type: diagnostic_aggregator/AnalyzerGroup


### PR DESCRIPTION
## Description
This reverts commit bffd80a34759926b722ab74f59b350f2dfa0334a.

related
- [TIER IV INTERNAL LINK](https://github.com/tier4/autoware_launch.x2/pull/303)
- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C042GG5L61X/p1686235455637619)