### PR TITLE
fix(aip x2): sensor timeout

### DIFF
--- a/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
@@ -68,4 +68,4 @@
               type: diagnostic_aggregator/GenericAnalyzer
               path: yaw_rate
               contains: [": yaw_rate_status"]
-              timeout: 3.0
+              timeout: 5.0

--- a/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/diagnostic_aggregator/sensor_kit.param.yaml
@@ -49,7 +49,7 @@
                       path: gnss
                       startswith: ["gnss"]
                       contains: [": gnss"]
-                      timeout: 30.0
+                      timeout: 5.0
                 node_alive_monitoring:
                   type: diagnostic_aggregator/AnalyzerGroup
                   path: node_alive_monitoring
@@ -58,7 +58,7 @@
                       type: diagnostic_aggregator/GenericAnalyzer
                       path: topic_status
                       contains: [": septentrio_topic_status"]
-                      timeout: 30.0
+                      timeout: 5.0
 
         imu:
           type: diagnostic_aggregator/AnalyzerGroup
@@ -68,4 +68,4 @@
               type: diagnostic_aggregator/GenericAnalyzer
               path: yaw_rate
               contains: [": yaw_rate_status"]
-              timeout: 1.0
+              timeout: 3.0

--- a/aip_x2_launch/launch/topic_state_monitor.launch.py
+++ b/aip_x2_launch/launch/topic_state_monitor.launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
                 "diag_name": "septentrio_topic_status",
                 "warn_rate": 2.5,
                 "error_rate": 0.5,
-                "timeout": 1.0,
+                "timeout": 5.0,
                 "window_size": 10,
             },
         ],


### PR DESCRIPTION
- Change timeout of `aggregator`.
  - Changed the timeout to 5 seconds because the diag such as `yaw_rate_status` is 1hz, so 1 second is too short.
  - Change timeout of `gnss's diag to 5 seconds.

- Changed the threshold of gnss's TOPIC rate monitoring
  - Shortened timeout.