### PR TITLE
fix(aip_xx1_launcher): fix with ars408.launch.xml

### DIFF
--- a/aip_xx1_launch/launch/radar.launch.xml
+++ b/aip_xx1_launch/launch/radar.launch.xml
@@ -17,6 +17,7 @@
         <arg name="input/frame" value="from_can_bus" />
         <arg name="output_frame" value="ars408" />
       </include>
+    </group>
 
     <node pkg="topic_tools" exec="relay" name="radar_relay" output="log" args="front_center/detected_objects detected_objects"/>
 

--- a/aip_xx1_launch/launch/radar.launch.xml
+++ b/aip_xx1_launch/launch/radar.launch.xml
@@ -13,8 +13,9 @@
       <node pkg="tf2_ros" exec="static_transform_publisher" name="base_link_to_ars408" output="screen" args="3.8 0.0 0.0 0.0 0.0 0.0 base_link ars408_front_center" />
 
       <include file="$(find-pkg-share common_sensor_launch)/launch/ars408.launch.xml">
-        <arg name="interface" value="can0" />
-        <arg name="input/frame" value="from_can_bus" />
+        <arg name="launch_driver" value="$(var launch_driver)" />
+        <arg name="interface" value="$(var radar_can_device)" />
+        <arg name="input/frame" value="$(var input/frame)" />
         <arg name="output_frame" value="ars408_front_center" />
       </include>
     </group>

--- a/aip_xx1_launch/launch/radar.launch.xml
+++ b/aip_xx1_launch/launch/radar.launch.xml
@@ -1,7 +1,6 @@
 <launch>
   <arg name="launch_driver" default="true" />
   <arg name="input/frame" default="from_can_bus" />
-  <arg name="output/objects" default="objects_raw" />
   <arg name="radar_can_device" default="canRadar" />
 
   <group>
@@ -9,6 +8,9 @@
 
     <group>
       <push-ros-namespace namespace="front_center"/>
+
+      <!-- tf launch (temporary) -->
+      <node pkg="tf2_ros" exec="static_transform_publisher" name="base_link_to_ars408" output="screen" args="3.8 0.0 0.0 0.0 0.0 0.0 base_link ars408_front_center" />
 
       <!-- socket can -->
       <group>
@@ -19,15 +21,14 @@
         </include>
       </group>
 
-      <!-- tf launch (temporary) -->
-      <node pkg="tf2_ros" exec="static_transform_publisher" name="base_link_to_ars408" output="screen" args="3.8 0.0 0.0 0.0 0.0 0.0 base_link ars408" />
-
       <include file="$(find-pkg-share pe_ars408_ros)/launch/continental_ars408.launch.xml">
         <arg name="input/frame" value="$(var input/frame)" />
-        <arg name="output/objects" value="$(var output/objects)" />
-        <arg name="launch_driver" value="$(var launch_driver)" />
+        <arg name="output_frame" value="ars408_front_center" />
       </include>
-
     </group>
+
+    <node pkg="topic_tools" exec="relay" name="radar_relay" output="log" args="front_center/detected_objects detected_objects"/>
+
   </group>
 </launch>
+

--- a/aip_xx1_launch/launch/radar.launch.xml
+++ b/aip_xx1_launch/launch/radar.launch.xml
@@ -31,4 +31,3 @@
 
   </group>
 </launch>
-

--- a/aip_xx1_launch/launch/radar.launch.xml
+++ b/aip_xx1_launch/launch/radar.launch.xml
@@ -12,20 +12,11 @@
       <!-- tf launch (temporary) -->
       <node pkg="tf2_ros" exec="static_transform_publisher" name="base_link_to_ars408" output="screen" args="3.8 0.0 0.0 0.0 0.0 0.0 base_link ars408_front_center" />
 
-      <!-- socket can -->
-      <group>
-        <include file="$(find-pkg-share pacmod3)/launch/pacmod3.launch.xml">
-          <arg name="use_socketcan" value="true" />
-          <arg name="socketcan_device" value="$(var radar_can_device)" />
-          <arg name="namespace" value="" />>
-        </include>
-      </group>
-
-      <include file="$(find-pkg-share pe_ars408_ros)/launch/continental_ars408.launch.xml">
-        <arg name="input/frame" value="$(var input/frame)" />
-        <arg name="output_frame" value="ars408_front_center" />
+      <include file="$(find-pkg-share common_sensor_launch)/launch/ars408.launch.xml">
+        <arg name="interface" value="can0" />
+        <arg name="input/frame" value="from_can_bus" />
+        <arg name="output_frame" value="ars408" />
       </include>
-    </group>
 
     <node pkg="topic_tools" exec="relay" name="radar_relay" output="log" args="front_center/detected_objects detected_objects"/>
 

--- a/aip_xx1_launch/launch/radar.launch.xml
+++ b/aip_xx1_launch/launch/radar.launch.xml
@@ -15,7 +15,7 @@
       <include file="$(find-pkg-share common_sensor_launch)/launch/ars408.launch.xml">
         <arg name="interface" value="can0" />
         <arg name="input/frame" value="from_can_bus" />
-        <arg name="output_frame" value="ars408" />
+        <arg name="output_frame" value="ars408_front_center" />
       </include>
     </group>
 

--- a/aip_xx1_launch/launch/sensing.launch.xml
+++ b/aip_xx1_launch/launch/sensing.launch.xml
@@ -32,7 +32,7 @@
     </include>
 
     <!-- Radar Driver -->
-    <include file="$(find-pkg-share aip_xx1_launch)/launch/radar.launch.xml" if="$(eval '&quot;$(var perception_mode)&quot;==&quot;camera_lidar_radar_fusion&quot;')">
+    <include file="$(find-pkg-share aip_xx1_launch)/launch/radar.launch.xml">
       <arg name="launch_driver" value="$(var launch_driver)" />
     </include>
 

--- a/common_sensor_launch/launch/ars408.launch.xml
+++ b/common_sensor_launch/launch/ars408.launch.xml
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="launch_driver" default="true" />
+
   <!-- socket can interface parameter -->
   <arg name="interface" default="can0" />
   <arg name="receiver_interval_sec" default="0.01"/>


### PR DESCRIPTION
Fix use ars408.launch.xml in aip_xx1_launcher

This PR replace to ars408.launch.xml in aip_xx1_launcher.
For commonality of radar input to detection in perception layer, radar output in sensing layer change `/sensing/radar/front_center/object_raw` into `/sensing/radar/detected_objects`

Note that this PR merge after [this PR](https://github.com/tier4/aip_launcher/pull/154)