### PR TITLE
feat(aip_x2_launch): add input topic remapping

### DIFF
--- a/aip_x2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x2_launch/launch/pointcloud_preprocessor.launch.py
@@ -31,7 +31,10 @@ def launch_setup(context, *args, **kwargs):
         package="pointcloud_preprocessor",
         plugin="pointcloud_preprocessor::PointCloudConcatenateDataSynchronizerComponent",
         name="concatenate_data",
-        remappings=[("output", "concatenated/pointcloud")],
+        remappings=[
+            ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
+            ("output", "concatenated/pointcloud"),
+        ],
         parameters=[
             {
                 "input_topics": [


### PR DESCRIPTION
https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/59
と同様にconcatenated nodeのtwistのトピック名を修正します。

> According to https://github.com/autowarefoundation/autoware.universe/pull/3877 change, add an argument to set the input topic name for concatenate data node.
Need to use this PR after https://github.com/autowarefoundation/autoware.universe/pull/3877 is merged to autoware.universe


なお、こちらのトピック名間違っていても速度補正されないだけで動きはする、とのこと