### PR TITLE
fix(common_sensor_launch): reinstate velodyne monitor

### DIFF
--- a/common_sensor_launch/launch/velodyne_VLP16.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLP16.launch.xml
@@ -37,4 +37,10 @@
     <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
     <arg name="container_name" value="$(var container_name)"/>
   </include>
+
+  <!-- Velodyne Monitor -->
+  <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
+    <arg name="ip_address" value="$(var device_ip)" />
+  </include>
+
 </launch>

--- a/common_sensor_launch/launch/velodyne_VLP32C.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLP32C.launch.xml
@@ -37,4 +37,10 @@
     <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
     <arg name="container_name" value="$(var container_name)"/>
   </include>
+
+  <!-- Velodyne Monitor -->
+  <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
+    <arg name="ip_address" value="$(var device_ip)" />
+  </include>
+
 </launch>

--- a/common_sensor_launch/launch/velodyne_VLS128.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLS128.launch.xml
@@ -42,5 +42,5 @@
   <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
     <arg name="ip_address" value="$(var device_ip)" />
   </include>
-  
+
 </launch>

--- a/common_sensor_launch/launch/velodyne_VLS128.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLS128.launch.xml
@@ -37,4 +37,10 @@
     <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
     <arg name="container_name" value="$(var container_name)"/>
   </include>
+
+  <!-- Velodyne Monitor -->
+  <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
+    <arg name="ip_address" value="$(var device_ip)" />
+  </include>
+  
 </launch>

--- a/common_sensor_launch/package.xml
+++ b/common_sensor_launch/package.xml
@@ -12,6 +12,7 @@
 
   <exec_depend>dummy_diag_publisher</exec_depend>
   <exec_depend>nebula_sensor_driver</exec_depend>
+  <exec_depend>velodyne_monitor</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
This PR adds `velodyne_monitor` to all Velodyne sensor launchfiles.
These were absent from launchfiles added when the driver used changed from Velodyne VLS to Nebula.