### PR TITLE
fix: fix vehicle_id reflection

### DIFF
--- a/aip_x1_launch/launch/imu.launch.xml
+++ b/aip_x1_launch/launch/imu.launch.xml
@@ -8,7 +8,7 @@
     <include file="$(find-pkg-share imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="/sensing/lidar/front_center/livox/imu" />
       <arg name="output_topic" value="/sensing/imu/imu_data" />
-      <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/aip_x1/imu_corrector.param.yaml" />
+      <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x1/imu_corrector.param.yaml" />
     </include>
 
   </group>

--- a/aip_x1_launch/launch/imu.launch.xml
+++ b/aip_x1_launch/launch/imu.launch.xml
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="launch_driver" default="true" />
+  <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
 
   <group>
     <push-ros-namespace namespace="imu"/>

--- a/aip_x1_launch/launch/sensing.launch.xml
+++ b/aip_x1_launch/launch/sensing.launch.xml
@@ -4,6 +4,7 @@
   <arg name="vehicle_mirror_param_file" description="path to the file of vehicle mirror position yaml"/>
   <arg name="use_pointcloud_container" default="false" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
 
   <group>
 

--- a/aip_x1_launch/launch/sensing.launch.xml
+++ b/aip_x1_launch/launch/sensing.launch.xml
@@ -34,7 +34,7 @@
     <include file="$(find-pkg-share vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">
       <arg name="input_vehicle_velocity_topic" value="/vehicle/status/velocity_status"/>
       <arg name="output_twist_with_covariance" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
-      <arg name="config_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/aip_x1/vehicle_velocity_converter.param.yaml" />
+      <arg name="config_file" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x1/vehicle_velocity_converter.param.yaml" />
     </include>
   </group>
 

--- a/aip_x2_launch/launch/imu.launch.xml
+++ b/aip_x2_launch/launch/imu.launch.xml
@@ -6,6 +6,7 @@
     <arg name="launch_driver" default="true" />
     <arg name="interface" default="pcan1"/>
     <arg name="receiver_interval_sec" default="0.01"/>
+    <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
 
     <group>
       <push-ros-namespace namespace="tamagawa"/>

--- a/aip_x2_launch/launch/imu.launch.xml
+++ b/aip_x2_launch/launch/imu.launch.xml
@@ -23,7 +23,7 @@
     <include file="$(find-pkg-share imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="tamagawa/imu_raw" />
       <arg name="output_topic" value="imu_data" />
-      <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/aip_x2/imu_corrector.param.yaml" />
+      <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/imu_corrector.param.yaml" />
     </include>
   </group>
 

--- a/aip_x2_launch/launch/sensing.launch.xml
+++ b/aip_x2_launch/launch/sensing.launch.xml
@@ -34,7 +34,7 @@
     <include file="$(find-pkg-share vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">
       <arg name="input_vehicle_velocity_topic" value="/vehicle/status/velocity_status"/>
       <arg name="output_twist_with_covariance" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
-      <arg name="config_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/aip_x2/vehicle_velocity_converter.param.yaml" />
+      <arg name="config_file" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/vehicle_velocity_converter.param.yaml" />
     </include>
   </group>
 

--- a/aip_x2_launch/launch/sensing.launch.xml
+++ b/aip_x2_launch/launch/sensing.launch.xml
@@ -4,6 +4,7 @@
   <arg name="vehicle_mirror_param_file" description="path to the file of vehicle mirror position yaml"/>
   <arg name="use_pointcloud_container" default="false" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
 
   <group>
 

--- a/aip_xx1_launch/launch/imu.launch.xml
+++ b/aip_xx1_launch/launch/imu.launch.xml
@@ -17,7 +17,7 @@
     <include file="$(find-pkg-share imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="tamagawa/imu_raw" />
       <arg name="output_topic" value="imu_data" />
-      <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/aip_xx1/imu_corrector.param.yaml" />
+      <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_xx1/imu_corrector.param.yaml" />
     </include>
   </group>
 

--- a/aip_xx1_launch/launch/imu.launch.xml
+++ b/aip_xx1_launch/launch/imu.launch.xml
@@ -1,6 +1,7 @@
 <launch>
 
   <arg name="launch_driver" default="true" />
+  <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
 
   <group>
     <push-ros-namespace namespace="imu"/>

--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -85,7 +85,7 @@
       <push-ros-namespace namespace="front_left"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/livox_horizon.launch.py">
         <arg name="sensor_frame" value="livox_front_left" />
-        <arg name="bd_code_param_path" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/aip_xx1/livox_front_left_bd_code.param.yaml" />
+        <arg name="bd_code_param_path" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_xx1/livox_front_left_bd_code.param.yaml" />
         <arg name="launch_driver" value="$(var launch_driver)" />
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)" />
       </include>
@@ -95,7 +95,7 @@
       <push-ros-namespace namespace="front_right"/>
       <include file="$(find-pkg-share common_sensor_launch)/launch/livox_horizon.launch.py">
         <arg name="sensor_frame" value="livox_front_right" />
-        <arg name="bd_code_param_path" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/aip_xx1/livox_front_right_bd_code.param.yaml" />
+        <arg name="bd_code_param_path" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_xx1/livox_front_right_bd_code.param.yaml" />
         <arg name="launch_driver" value="$(var launch_driver)" />
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)" />
       </include>

--- a/aip_xx1_launch/launch/sensing.launch.xml
+++ b/aip_xx1_launch/launch/sensing.launch.xml
@@ -5,6 +5,7 @@
   <arg name="perception_mode" default="camera_lidar_fusion" description="select perception mode. camera_lidar_fusion, lidar, camera"/>
   <arg name="use_pointcloud_container" default="false" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
 
   <group>
 
@@ -32,9 +33,9 @@
     </include>
 
     <!-- Radar Driver -->
-    <include file="$(find-pkg-share aip_xx1_launch)/launch/radar.launch.xml">
+    <!-- <include file="$(find-pkg-share aip_xx1_launch)/launch/radar.launch.xml">
       <arg name="launch_driver" value="$(var launch_driver)" />
-    </include>
+    </include> -->
 
     <!-- Vehicle twist -->
     <include file="$(find-pkg-share vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">

--- a/aip_xx1_launch/launch/sensing.launch.xml
+++ b/aip_xx1_launch/launch/sensing.launch.xml
@@ -33,9 +33,9 @@
     </include>
 
     <!-- Radar Driver -->
-    <!-- <include file="$(find-pkg-share aip_xx1_launch)/launch/radar.launch.xml">
+    <include file="$(find-pkg-share aip_xx1_launch)/launch/radar.launch.xml">
       <arg name="launch_driver" value="$(var launch_driver)" />
-    </include> -->
+    </include>
 
     <!-- Vehicle twist -->
     <include file="$(find-pkg-share vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">

--- a/aip_xx1_launch/launch/sensing.launch.xml
+++ b/aip_xx1_launch/launch/sensing.launch.xml
@@ -40,7 +40,7 @@
     <include file="$(find-pkg-share vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">
       <arg name="input_vehicle_velocity_topic" value="/vehicle/status/velocity_status"/>
       <arg name="output_twist_with_covariance" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
-      <arg name="config_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/aip_xx1/vehicle_velocity_converter.param.yaml" />
+      <arg name="config_file" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_xx1/vehicle_velocity_converter.param.yaml" />
     </include>
 
   </group>


### PR DESCRIPTION
Current implementation of aip_launcher does not reflect the vehicle_id when passing the argument without using the environment variable.
```bash
ros2 launch autoware_launch ... vehicle_id:=XXX
```

Thus, I would like to modify the script so that both (whether specifying by argument or environment variable) would work.

I confirmed that both `vehicle_velocity_converter` and `imu_corrector` parameters are reflected with the above command, using `ros2 param dump`. 