### PR TITLE
fix(nebula launch): consistent naming for sensor_ip parameter

### DIFF
--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -16,7 +16,7 @@
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLS128.launch.xml">
         <arg name="max_range" value="250.0"/>
         <arg name="sensor_frame" value="velodyne_top"/>
-        <arg name="device_ip" value="192.168.1.201"/>
+        <arg name="sensor_ip" value="192.168.1.201"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2368"/>
         <arg name="scan_phase" value="300.0"/>
@@ -32,7 +32,7 @@
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
         <arg name="max_range" value="5.0"/>
         <arg name="sensor_frame" value="velodyne_left"/>
-        <arg name="device_ip" value="192.168.1.202"/>
+        <arg name="sensor_ip" value="192.168.1.202"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2369"/>
         <arg name="scan_phase" value="180.0"/>
@@ -50,7 +50,7 @@
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
         <arg name="max_range" value="5.0"/>
         <arg name="sensor_frame" value="velodyne_right"/>
-        <arg name="device_ip" value="192.168.1.203"/>
+        <arg name="sensor_ip" value="192.168.1.203"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2370"/>
         <arg name="scan_phase" value="180.0"/>
@@ -68,7 +68,7 @@
       <include file="$(find-pkg-share common_sensor_launch)/launch/velodyne_VLP16.launch.xml">
         <arg name="max_range" value="1.5"/>
         <arg name="sensor_frame" value="velodyne_rear"/>
-        <arg name="device_ip" value="192.168.1.204"/>
+        <arg name="sensor_ip" value="192.168.1.204"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2371"/>
         <arg name="scan_phase" value="180.0"/>

--- a/common_sensor_launch/launch/hesai_XT32.launch.xml
+++ b/common_sensor_launch/launch/hesai_XT32.launch.xml
@@ -6,7 +6,7 @@
   <arg name="model" default="PandarXT32"/>
   <arg name="sensor_frame" default="pandar"/>
   <arg name="return_mode" default="Strongest"/>
-  <arg name="device_ip" default="192.168.1.201"/>
+  <arg name="sensor_ip" default="192.168.1.201"/>
   <arg name="host_ip" default="255.255.255.255"/>
   <arg name="data_port" default="2368"/>
   <arg name="scan_phase" default="0.0"/>
@@ -22,7 +22,7 @@
     <arg name="sensor_model" value="$(var model)"/>
     <arg name="return_mode" value="$(var return_mode)"/>
     <arg name="frame_id" value="$(var sensor_frame)"/>
-    <arg name="device_ip" value="$(var device_ip)"/>
+    <arg name="sensor_ip" value="$(var sensor_ip)"/>
     <arg name="host_ip" value="$(var host_ip)"/>
     <arg name="data_port" value="$(var data_port)"/>
     <arg name="scan_phase" value="$(var scan_phase)"/>

--- a/common_sensor_launch/launch/velodyne_VLP16.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLP16.launch.xml
@@ -8,7 +8,7 @@
   <arg name="min_range" default="0.4"/>
   <arg name="sensor_frame" default="velodyne"/>
   <arg name="return_mode" default="SingleStrongest"/>
-  <arg name="device_ip" default="192.168.1.201"/>
+  <arg name="sensor_ip" default="192.168.1.201"/>
   <arg name="host_ip" default="255.255.255.255"/>
   <arg name="data_port" default="2368"/>
   <arg name="scan_phase" default="0.0"/>
@@ -25,7 +25,7 @@
     <arg name="max_range" value="$(var max_range)"/>
     <arg name="min_range" value="$(var min_range)"/>
     <arg name="frame_id" value="$(var sensor_frame)"/>
-    <arg name="sensor_ip" value="$(var device_ip)"/>
+    <arg name="sensor_ip" value="$(var sensor_ip)"/>
     <arg name="host_ip" value="$(var host_ip)"/>
     <arg name="data_port" value="$(var data_port)"/>
     <arg name="scan_phase" value="$(var scan_phase)"/>
@@ -40,7 +40,7 @@
 
   <!-- Velodyne Monitor -->
   <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
-    <arg name="ip_address" value="$(var device_ip)" />
+    <arg name="ip_address" value="$(var sensor_ip)"/>
   </include>
 
 </launch>

--- a/common_sensor_launch/launch/velodyne_VLP32C.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLP32C.launch.xml
@@ -8,7 +8,7 @@
   <arg name="min_range" default="0.4"/>
   <arg name="sensor_frame" default="velodyne"/>
   <arg name="return_mode" default="SingleStrongest"/>
-  <arg name="device_ip" default="192.168.1.201"/>
+  <arg name="sensor_ip" default="192.168.1.201"/>
   <arg name="host_ip" default="255.255.255.255"/>
   <arg name="data_port" default="2368"/>
   <arg name="scan_phase" default="0.0"/>
@@ -25,7 +25,7 @@
     <arg name="max_range" value="$(var max_range)"/>
     <arg name="min_range" value="$(var min_range)"/>
     <arg name="frame_id" value="$(var sensor_frame)"/>
-    <arg name="sensor_ip" value="$(var device_ip)"/>
+    <arg name="sensor_ip" value="$(var sensor_ip)"/>
     <arg name="host_ip" value="$(var host_ip)"/>
     <arg name="data_port" value="$(var data_port)"/>
     <arg name="scan_phase" value="$(var scan_phase)"/>
@@ -40,7 +40,7 @@
 
   <!-- Velodyne Monitor -->
   <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
-    <arg name="ip_address" value="$(var device_ip)" />
+    <arg name="ip_address" value="$(var sensor_ip)"/>
   </include>
 
 </launch>

--- a/common_sensor_launch/launch/velodyne_VLS128.launch.xml
+++ b/common_sensor_launch/launch/velodyne_VLS128.launch.xml
@@ -8,7 +8,7 @@
   <arg name="min_range" default="0.5"/>
   <arg name="sensor_frame" default="velodyne"/>
   <arg name="return_mode" default="SingleStrongest"/>
-  <arg name="device_ip" default="192.168.1.201"/>
+  <arg name="sensor_ip" default="192.168.1.201"/>
   <arg name="host_ip" default="255.255.255.255"/>
   <arg name="data_port" default="2368"/>
   <arg name="scan_phase" default="0.0"/>
@@ -25,7 +25,7 @@
     <arg name="max_range" value="$(var max_range)"/>
     <arg name="min_range" value="$(var min_range)"/>
     <arg name="frame_id" value="$(var sensor_frame)"/>
-    <arg name="sensor_ip" value="$(var device_ip)"/>
+    <arg name="sensor_ip" value="$(var sensor_ip)"/>
     <arg name="host_ip" value="$(var host_ip)"/>
     <arg name="data_port" value="$(var data_port)"/>
     <arg name="scan_phase" value="$(var scan_phase)"/>
@@ -40,7 +40,7 @@
 
   <!-- Velodyne Monitor -->
   <include file="$(find-pkg-share velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
-    <arg name="ip_address" value="$(var device_ip)" />
+    <arg name="ip_address" value="$(var sensor_ip)"/>
   </include>
 
 </launch>


### PR DESCRIPTION
For XX1 launcher, changes all `device_ip` parameters to `sensor_ip` in order to ensure the correct IP address is assigned.
This was causing launch errors for XT32, where incorrect use of `device_ip` led to all sensors being configured to the same IP when multiple sensors are used.