### PR TITLE
chore(aip_x2_launch): add blockage diagnostics enable option

### DIFF
--- a/aip_x2_launch/launch/pandar_node_container.launch.py
+++ b/aip_x2_launch/launch/pandar_node_container.launch.py
@@ -300,6 +300,7 @@ def launch_setup(context, *args, **kwargs):
     blockage_diag_loader = LoadComposableNodes(
         composable_node_descriptions=[blockage_diag_component],
         target_container=container,
+        condition=launch.conditions.IfCondition(LaunchConfiguration("enable_blockage_diag")),
     )
 
     return [
@@ -347,6 +348,7 @@ def generate_launch_description():
 
     add_launch_arg("min_azimuth_deg", "135.0")
     add_launch_arg("max_azimuth_deg", "225.0")
+    add_launch_arg("enable_blockage_diag", "true")
     set_container_executable = SetLaunchConfiguration(
         "container_executable",
         "component_container",


### PR DESCRIPTION
X2で現在　通常にLiDARのBlockage_diagのノーどが起動する状態なので、変更可能パラメータを追加しておきます。