### PR TITLE
fix(aip_launcher_x2): use only front radar for radar faraway detection

### DIFF
--- a/aip_x1_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x1_launch/launch/pointcloud_preprocessor.launch.py
@@ -32,7 +32,7 @@ def launch_setup(context, *args, **kwargs):
         name="concatenate_data",
         remappings=[
             ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
-            ("output", "concatenated/pointcloud")
+            ("output", "concatenated/pointcloud"),
         ],
         parameters=[
             {

--- a/aip_x2_launch/launch/radar.launch.xml
+++ b/aip_x2_launch/launch/radar.launch.xml
@@ -64,7 +64,9 @@
       <arg name="update_rate_hz" value="20.0"/>
       <arg name="new_frame_id" value="base_link"/>
       <arg name="timeout_threshold" value="1.0"/>
-      <arg name="input_topics" value="[/sensing/radar/front_center/detected_objects, /sensing/radar/front_left/detected_objects, /sensing/radar/rear_left/detected_objects, /sensing/radar/rear_center/detected_objects, /sensing/radar/rear_right/detected_objects, /sensing/radar/front_right/detected_objects]"/>
+      <!-- To reduce calculation cost, use only front radar for radar detection -->
+      <!--<arg name="input_topics" value="[/sensing/radar/front_center/detected_objects, /sensing/radar/front_left/detected_objects, /sensing/radar/rear_left/detected_objects, /sensing/radar/rear_center/detected_objects, /sensing/radar/rear_right/detected_objects, /sensing/radar/front_right/detected_objects]"/>-->
+      <arg name="input_topics" value="[/sensing/radar/front_center/detected_objects, /sensing/radar/front_left/detected_objects, /sensing/radar/front_right/detected_objects]"/>
     </include>
 
   </group>


### PR DESCRIPTION
fix(aip_launcher_x2): use only front radar for radar faraway detection

This PR fixes node order in radar faraway detection to reduce calculation cost.
