### PR TITLE
fix(aip_launcher_x2): add doppler velocity output in driver[kuwana][gsm8]

### DIFF
--- a/aip_x2_launch/config/mosaic_x5_rover.param.yaml
+++ b/aip_x2_launch/config/mosaic_x5_rover.param.yaml
@@ -36,7 +36,7 @@
       gprmc: false
       gpst : false
       measepoch: false
-      pvtcartesian: false
+      pvtcartesian: true
       pvtgeodetic: true
       poscovcartesian: false
       poscovgeodetic: true


### PR DESCRIPTION
## Description
In current GSM8, the GNSS Doppler velocity is only available in the ENU coordinate system, and EagleEye requires the ECEF coordinate system. Therefore, it is necessary to set the parameter pvtCartesian to true.
## Related links

https://github.com/tier4/autoware_launch.x2/pull/552
https://github.com/tier4/pilot-auto.x2/pull/493
https://github.com/tier4/autoware.universe/pull/1039