### PR TITLE
fix(gnss.launch): topic namespace

### DIFF
--- a/aip_x2_launch/launch/gnss.launch.xml
+++ b/aip_x2_launch/launch/gnss.launch.xml
@@ -8,9 +8,9 @@
     <!-- Septentrio Mosaic Driver -->
     <node pkg="septentrio_gnss_driver" name="septentrio" exec="septentrio_gnss_driver_node" if="$(var launch_driver)">
       <param from="$(find-pkg-share aip_x2_launch)/config/mosaic_x5_rover.param.yaml"/>
-      <remap from="/navsatfix" to="~/nav_sat_fix"/>
-      <remap from="/poscovgeodetic" to="~/poscovgeodetic"/>
-      <remap from="/pvtgeodetic" to="~/pvtgeodetic"/>
+      <remap from="navsatfix" to="~/nav_sat_fix"/>
+      <remap from="poscovgeodetic" to="~/poscovgeodetic"/>
+      <remap from="pvtgeodetic" to="~/pvtgeodetic"/>
     </node>
 
     <!-- NavSatFix to MGRS Pose -->


### PR DESCRIPTION
## Description
Since the output topic of septentrio gnss driver was changed, I fixed it.
- https://github.com/septentrio-gnss/septentrio_gnss_driver/pull/97/commits/d6354103b4b14fc736ae023067a8befa1f1ce7a3

## Test
I confirmed this works in bench.