### PR TITLE
feat(concatenation): separate concatenate node from other preprocessing nodes' container

### DIFF
--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -106,7 +106,7 @@
       <arg name="use_intra_process" value="true"/>
       <arg name="use_multithread" value="true"/>
       <arg name="use_pointcloud_container" value="true"/>
-      <arg name="container_name" value="/sensing/lidar/top/pointcloud_preprocessor/pointcloud_container"/>
+      <arg name="container_name" value="$(var pointcloud_container_name)"/>
     </include>
 
   </group>

--- a/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
@@ -57,19 +57,12 @@ def launch_setup(context, *args, **kwargs):
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
-    glog_component = ComposableNode(
-        package="glog_component",
-        plugin="GlogComponent",
-        name="glog_component",
-    )
-
     # set container to run all required components in the same process
     container = ComposableNodeContainer(
         name=LaunchConfiguration("container_name"),
         namespace="",
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
-        composable_node_descriptions=[glog_component],
         condition=UnlessCondition(LaunchConfiguration("use_pointcloud_container")),
         output="screen",
     )
@@ -82,7 +75,7 @@ def launch_setup(context, *args, **kwargs):
 
     # load concat or passthrough filter
     concat_loader = LoadComposableNodes(
-        composable_node_descriptions=[concat_component, glog_component],
+        composable_node_descriptions=[concat_component],
         target_container=target_container,
         condition=IfCondition(LaunchConfiguration("use_concat_filter")),
     )


### PR DESCRIPTION
## Description
Separate concatenation node from Top LiDAR container in order to enhance the redundancy.

In addition, moving the concatenation node to `/pointcloud_container` resulted in duplicated declaration of `glog_component` (here and ground_segmentation.launch.py). Since `pointcloud_container` is a single process declared in `autoware.launch.xml`, I would like to modify the `glog_component` declaration as well.
- https://github.com/autowarefoundation/autoware.universe/pull/6081
- https://github.com/autowarefoundation/autoware_launch/pull/791

![image](https://github.com/tier4/aip_launcher/assets/44218668/63af85a7-3384-4806-acac-ec69efad753b)

Note that some other nodes such as `lidar_centerpoint` will be added in this `/pointcloud_container` later on.

## Tests performed
I have tested the PR with JPN TAXI to see if the performance regression is negligible or not.
The results are written here: [TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT1-4912). We observed a slight delay in the deriving topics from concatenated/pointcloud, which is around ~10ms in average.

## Possible effects
Increase in CPU usage is expected since it will increase the inter-process communication (mostly in a single computer). However, we estimate this risk small enough given the above delay estimation results.

## Related links
[TIER IV INTERNAL LINK FOR SLACK
](https://star4.slack.com/archives/C03S84LDJGG/p1704879117977909)
PRs that needs to be merged with:
- https://github.com/autowarefoundation/autoware.universe/pull/6081
- https://github.com/autowarefoundation/autoware_launch/pull/791