### PR TITLE
chore(nebula_node_container): enhance logging

### DIFF
--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -88,6 +88,14 @@ def launch_setup(context, *args, **kwargs):
 
     nodes.append(
         ComposableNode(
+            package="glog_component",
+            plugin="GlogComponent",
+            name="glog_component",
+        )
+    )
+
+    nodes.append(
+        ComposableNode(
             package="nebula_ros",
             plugin=sensor_make + "DriverRosWrapper",
             name=sensor_make.lower() + "_driver_ros_wrapper_node",
@@ -200,7 +208,7 @@ def launch_setup(context, *args, **kwargs):
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=nodes,
-        output="screen",
+        output="both",
     )
 
     driver_component = ComposableNode(


### PR DESCRIPTION
Enhance logging of nebula_node_container.
- Add `glog_component` in nebula_node_container so that all the LiDAR preprocessing container will have glog enabled
- Change logging configuration from "screen" to "both" so that the log will be written to the log file as well as terminal

Related: https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/86