### PR TITLE
fix(gnss_launcher): remove gnss_frame arg

### DIFF
--- a/aip_x1_launch/launch/gnss.launch.xml
+++ b/aip_x1_launch/launch/gnss.launch.xml
@@ -22,8 +22,6 @@
       <arg name="output_topic_gnss_fixed" value="fixed" />
 
       <arg name="use_ublox_receiver" value="true" />
-
-      <arg name="gnss_frame" value="gnss_link" />
     </include>
 
   </group>

--- a/aip_x2_launch/launch/gnss.launch.xml
+++ b/aip_x2_launch/launch/gnss.launch.xml
@@ -23,8 +23,6 @@
       <arg name="output_topic_gnss_fixed" value="fixed" />
 
       <arg name="use_ublox_receiver" value="true" />
-
-      <arg name="gnss_frame" value="gnss_link" />
     </include>
 
   </group>

--- a/aip_xx1_launch/launch/gnss.launch.xml
+++ b/aip_xx1_launch/launch/gnss.launch.xml
@@ -35,8 +35,6 @@
       <arg name="output_topic_gnss_fixed" value="fixed" />
 
       <arg name="use_ublox_receiver" value="true" />
-
-      <arg name="gnss_frame" value="gnss_link" />
     </include>
 
   </group>


### PR DESCRIPTION
## Description

I removed `gnss_frame` arg.

gnns_poser refers to `msg.header.frame_id` instead of parameter `gnss_frame`.
Please see https://github.com/autowarefoundation/autoware.universe/pull/6116

(The original reason why we can not pass `gnss_frame` as arg is https://github.com/autowarefoundation/autoware.universe/pull/5140 )

[TIER IV INTERNAL ANNOUNCEMENT LINK](https://star4.slack.com/archives/C4P0NSMB5/p1705640076668249)