### PR TITLE
fix(aip-x2_launch): gnss frame_id (#190)

### DIFF
--- a/aip_x2_launch/config/mosaic_x5_rover.param.yaml
+++ b/aip_x2_launch/config/mosaic_x5_rover.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     device: tcp://192.168.100.101:28784
 
-    frame_id: gnss_right_link
+    frame_id: gnss_link
     aux1_frame_id: aux1
     get_spatial_config_from_tf: false
     use_ros_axis_orientation: false


### PR DESCRIPTION
## Related links
- https://github.com/tier4/aip_launcher/pull/190
- https://github.com/tier4/aip_launcher/pull/141

## Description
Incorporate the fix of frame_id in septentrio gnss driver to beta branch.