### PR TITLE
chore(common_sensor_launch): remove nebula dependency to avoid rosdep error

### DIFF
--- a/common_sensor_launch/package.xml
+++ b/common_sensor_launch/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>dummy_diag_publisher</exec_depend>
-  <exec_depend>nebula_sensor_driver</exec_depend>
   <exec_depend>radar_tracks_msgs_converter</exec_depend>
   <exec_depend>radar_tracks_noise_filter</exec_depend>
   <exec_depend>velodyne_monitor</exec_depend>


### PR DESCRIPTION
## Related links
[TIER IV INTERNAL](https://star4.slack.com/archives/CRUE57C30/p1705899508560289)

## Descpription
I removed dependency on nebula driver to avoid rosdep error.

NOTE:
nebula driver is temporarily removed to avoid errors caused by duplicated `pandar_msgs`.

```
[1.246s] ERROR:colcon:colcon build: Duplicate package names not supported:
- pandar_msgs:
  - src/vendor/hesai_pandar/pandar_msgs
  - src/vendor/nebula/nebula_messages/pandar_msgs
```