### PR TITLE
fix(gnss.launch): topic namespace (#193)

### DIFF
--- a/aip_x2_launch/launch/gnss.launch.xml
+++ b/aip_x2_launch/launch/gnss.launch.xml
@@ -8,9 +8,9 @@
     <!-- Septentrio Mosaic Driver -->
     <node pkg="septentrio_gnss_driver" name="septentrio" exec="septentrio_gnss_driver_node" if="$(var launch_driver)">
       <param from="$(find-pkg-share aip_x2_launch)/config/mosaic_x5_rover.param.yaml"/>
-      <remap from="/navsatfix" to="~/nav_sat_fix"/>
-      <remap from="/poscovgeodetic" to="~/poscovgeodetic"/>
-      <remap from="/pvtgeodetic" to="~/pvtgeodetic"/>
+      <remap from="navsatfix" to="~/nav_sat_fix"/>
+      <remap from="poscovgeodetic" to="~/poscovgeodetic"/>
+      <remap from="pvtgeodetic" to="~/pvtgeodetic"/>
     </node>
 
     <!-- NavSatFix to MGRS Pose -->


### PR DESCRIPTION
## Related links
- https://github.com/tier4/aip_launcher/pull/193

## Descpription
Incorporate the fix of the gnss topic name.