### PR TITLE
feat: add imu_monitor and dummy diag

### DIFF
--- a/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -15,6 +15,9 @@
       # gnss
       gnss: default
 
+      # imu
+      yaw_rate_status: default
+
       # lidar
       pandar_connection: default
       pandar_temperature: default

--- a/aip_x2_launch/launch/imu.launch.xml
+++ b/aip_x2_launch/launch/imu.launch.xml
@@ -34,6 +34,10 @@
       <arg name="input_odom" value="/localization/kinematic_state"/>
       <arg name="imu_corrector_param_file" value="$(var imu_corrector_param_file)"/>
     </include>
+
+    <include file="$(find-pkg-share imu_monitor)/launch/imu_monitor.launch.xml">
+      <arg name="config_file" value="$(find-pkg-share imu_monitor)/config/imu_monitor.param.yaml"/>
+    </include>
   </group>
 
 </launch>


### PR DESCRIPTION
## Descriptions
imu_monitorおよびそのdummy diagを追加

## Related Links
https://tier4.atlassian.net/browse/RT0-30650

## Tests Performed
下記コマンドでautowareを起動し、
- imu_monitorがros2 node listで存在している
- rqt_runtime_monitorでdiagが存在している
ことを確認した
```
$ ros2 launch autoware_launch autoware.launch.xml vehicle_model:=j6_gen1 sensor_model:=aip_x2 vehicle_id:=j6_gen1_01 map_path:=$HOME/map/X2/Shiojiri/ pointcloud_map_file:=pcd centerpoint_model_path:=$HOME/Downloads/centerpoint/ centerpoint_model_param_path:=$HOME/Downloads/centerpoint/aip_x2.param.yaml launch_vehicle:=false launch_system:=false launch_map:=false launch_sensing:=true launch_localization:=false launch_perception:=false launch_planning:=false launch_control:=false launch_v2x:=false launch_api:=false launch_l4_toolkit:=false
```

下記コマンドでplanning_simulatorを起動し、dumy diagが存在していることを確認した
```
$ ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=j6_gen1 sensor_model:=aip_x2 vehicle_id:=j6_gen1_01 map_path:=$HOME/map/X2/Shiojiri/ pointcloud_map_file:=pcd launch_dummy_diag_publisher:=true
```