### PR TITLE
feat(update): update lidar pointcloud interface and concatenate pointcloud filter

### DIFF
--- a/aip_x1_launch/launch/new_livox_horizon.launch.py
+++ b/aip_x1_launch/launch/new_livox_horizon.launch.py
@@ -52,12 +52,12 @@ def get_crop_box_min_range_component(context, livox_frame_id):
         name="crop_box_filter_min_range",
         remappings=[
             ("input", "livox/tag_filtered/lidar" if use_tag_filter else "livox/lidar"),
-            ("output", "min_range_cropped/pointcloud"),
+            ("output", "min_range_cropped/pointcloud_before_sync"),
         ],
         parameters=[
             {
                 "input_frame": livox_frame_id,
-                "output_frame": LaunchConfiguration("base_frame"),
+                "output_frame": LaunchConfiguration("frame_id"),
                 "min_x": 0.0,
                 "max_x": LaunchConfiguration("min_range"),
                 "min_y": -2.0,

--- a/aip_x1_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x1_launch/launch/pointcloud_preprocessor.launch.py
@@ -36,14 +36,15 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             {
                 "input_topics": [
-                    "/sensing/lidar/top/pointcloud",
-                    "/sensing/lidar/front_left/min_range_cropped/pointcloud",
-                    "/sensing/lidar/front_right/min_range_cropped/pointcloud",
-                    "/sensing/lidar/front_center/min_range_cropped/pointcloud",
+                    "/sensing/lidar/top/pointcloud_before_sync",
+                    "/sensing/lidar/front_left/min_range_cropped/pointcloud_before_sync",
+                    "/sensing/lidar/front_right/min_range_cropped/pointcloud_before_sync",
+                    "/sensing/lidar/front_center/min_range_cropped/pointcloud_before_sync",
                 ],
                 "output_frame": LaunchConfiguration("base_frame"),
                 "timeout_sec": 1.0,
                 "input_twist_topic_type": "twist",
+                "publish_synchronized_pointcloud": True,
             }
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],

--- a/aip_x1_launch/launch/velodyne_node_container.launch.py
+++ b/aip_x1_launch/launch/velodyne_node_container.launch.py
@@ -121,6 +121,13 @@ def launch_setup(context, *args, **kwargs):
         )
     )
 
+    # Ring Outlier Filter is the last component in the pipeline, so control the output frame here
+    if LaunchConfiguration("output_as_sensor_frame").perform(context):
+        ring_outlier_filter_parameters = {"output_frame": LaunchConfiguration("frame_id")}
+    else:
+        ring_outlier_filter_parameters = {
+            "output_frame": ""
+        }  # keep the output frame as the input frame
     nodes.append(
         ComposableNode(
             package="pointcloud_preprocessor",
@@ -128,8 +135,9 @@ def launch_setup(context, *args, **kwargs):
             name="ring_outlier_filter",
             remappings=[
                 ("input", "rectified/pointcloud_ex"),
-                ("output", "pointcloud"),
+                ("output", "pointcloud_before_sync"),
             ],
+            parameters=[ring_outlier_filter_parameters],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )
     )
@@ -218,6 +226,7 @@ def generate_launch_description():
     )
     add_launch_arg("use_multithread", "False", "use multithread")
     add_launch_arg("use_intra_process", "False", "use ROS2 component container communication")
+    add_launch_arg("output_as_sensor_frame", "True", "output final pointcloud in sensor frame")
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",

--- a/aip_x2_launch/launch/pandar_node_container.launch.py
+++ b/aip_x2_launch/launch/pandar_node_container.launch.py
@@ -202,14 +202,22 @@ def launch_setup(context, *args, **kwargs):
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
+    # Ring Outlier Filter is the last component in the pipeline, so control the output frame here
+    if LaunchConfiguration("output_as_sensor_frame").perform(context):
+        ring_outlier_filter_parameters = {"output_frame": LaunchConfiguration("frame_id")}
+    else:
+        ring_outlier_filter_parameters = {
+            "output_frame": ""
+        }  # keep the output frame as the input frame
     ring_outlier_filter_component = ComposableNode(
         package="pointcloud_preprocessor",
         plugin="pointcloud_preprocessor::RingOutlierFilterComponent",
         name="ring_outlier_filter",
         remappings=[
             ("input", "rectified/pointcloud_ex"),
-            ("output", "pointcloud"),
+            ("output", "pointcloud_before_sync"),
         ],
+        parameters=[ring_outlier_filter_parameters],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
@@ -336,6 +344,7 @@ def generate_launch_description():
     add_launch_arg("min_azimuth_deg", "135.0")
     add_launch_arg("max_azimuth_deg", "225.0")
     add_launch_arg("enable_blockage_diag", "true")
+    add_launch_arg("output_as_sensor_frame", "True", "output final pointcloud in sensor frame")
     set_container_executable = SetLaunchConfiguration(
         "container_executable",
         "component_container",

--- a/aip_x2_launch/launch/pandar_node_container.launch.py
+++ b/aip_x2_launch/launch/pandar_node_container.launch.py
@@ -344,7 +344,7 @@ def generate_launch_description():
     add_launch_arg("min_azimuth_deg", "135.0")
     add_launch_arg("max_azimuth_deg", "225.0")
     add_launch_arg("enable_blockage_diag", "true")
-    add_launch_arg("output_as_sensor_frame", "True", "output final pointcloud in sensor frame")
+    add_launch_arg("output_as_sensor_frame", "True")
     set_container_executable = SetLaunchConfiguration(
         "container_executable",
         "component_container",

--- a/aip_x2_launch/launch/pandar_node_container.launch.py
+++ b/aip_x2_launch/launch/pandar_node_container.launch.py
@@ -227,7 +227,7 @@ def launch_setup(context, *args, **kwargs):
         name="dual_return_filter",
         remappings=[
             ("input", "rectified/pointcloud_ex"),
-            ("output", "pointcloud"),
+            ("output", "pointcloud_before_sync"),
         ],
         parameters=[
             {

--- a/aip_x2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x2_launch/launch/pointcloud_preprocessor.launch.py
@@ -37,19 +37,20 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             {
                 "input_topics": [
-                    "/sensing/lidar/front_upper/pointcloud",
-                    "/sensing/lidar/front_lower/pointcloud",
-                    "/sensing/lidar/left_upper/pointcloud",
-                    "/sensing/lidar/left_lower/pointcloud",
-                    "/sensing/lidar/right_upper/pointcloud",
-                    "/sensing/lidar/right_lower/pointcloud",
-                    "/sensing/lidar/rear_upper/pointcloud",
-                    "/sensing/lidar/rear_lower/pointcloud",
+                    "/sensing/lidar/front_upper/pointcloud_before_sync",
+                    "/sensing/lidar/front_lower/pointcloud_before_sync",
+                    "/sensing/lidar/left_upper/pointcloud_before_sync",
+                    "/sensing/lidar/left_lower/pointcloud_before_sync",
+                    "/sensing/lidar/right_upper/pointcloud_before_sync",
+                    "/sensing/lidar/right_lower/pointcloud_before_sync",
+                    "/sensing/lidar/rear_upper/pointcloud_before_sync",
+                    "/sensing/lidar/rear_lower/pointcloud_before_sync",
                 ],
                 "input_offset": [0.025, 0.025, 0.01, 0.0, 0.05, 0.05, 0.05, 0.05],
                 "timeout_sec": 0.075,
                 "output_frame": LaunchConfiguration("base_frame"),
                 "input_twist_topic_type": "twist",
+                "publish_synchronized_pointcloud": True,
             }
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],

--- a/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
@@ -37,10 +37,10 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             {
                 "input_topics": [
-                    "/sensing/lidar/top/pointcloud",
-                    "/sensing/lidar/left/pointcloud",
-                    "/sensing/lidar/right/pointcloud",
-                    "/sensing/lidar/rear/pointcloud",
+                    "/sensing/lidar/top/pointcloud_before_sync",
+                    "/sensing/lidar/left/pointcloud_before_sync",
+                    "/sensing/lidar/right/pointcloud_before_sync",
+                    "/sensing/lidar/rear/pointcloud_before_sync",
                 ],
                 "output_frame": LaunchConfiguration("base_frame"),
                 "input_offset": [
@@ -51,6 +51,7 @@ def launch_setup(context, *args, **kwargs):
                 ],  # each sensor will wait 60, 70, 70, 70ms
                 "timeout_sec": 0.095,  # set shorter than 100ms
                 "input_twist_topic_type": "twist",
+                "publish_synchronized_pointcloud": True,
             }
         ],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],

--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -188,6 +188,13 @@ def launch_setup(context, *args, **kwargs):
         )
     )
 
+    # Ring Outlier Filter is the last component in the pipeline, so control the output frame here
+    if LaunchConfiguration("output_as_sensor_frame").perform(context):
+        ring_outlier_filter_parameters = {"output_frame": LaunchConfiguration("frame_id")}
+    else:
+        ring_outlier_filter_parameters = {
+            "output_frame": ""
+        }  # keep the output frame as the input frame
     nodes.append(
         ComposableNode(
             package="pointcloud_preprocessor",
@@ -195,8 +202,9 @@ def launch_setup(context, *args, **kwargs):
             name="ring_outlier_filter",
             remappings=[
                 ("input", "rectified/pointcloud_ex"),
-                ("output", "pointcloud"),
+                ("output", "pointcloud_before_sync"),
             ],
+            parameters=[ring_outlier_filter_parameters],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )
     )
@@ -283,6 +291,7 @@ def generate_launch_description():
     add_launch_arg("use_multithread", "False", "use multithread")
     add_launch_arg("use_intra_process", "False", "use ROS 2 component container communication")
     add_launch_arg("container_name", "nebula_node_container")
+    add_launch_arg("output_as_sensor_frame", "True", "output final pointcloud in sensor frame")
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",


### PR DESCRIPTION
# PRの目的

Interface change discussion:
https://github.com/orgs/autowarefoundation/discussions/4158

下記の変更を執り行います。

- lidarの出力フレームをsensorのフレームに変更
- `<lidar>/pointcloud`のtopicの発行元を点群のconcatenateの直前からsyncした途中の点に変更


# 背景

各lidarセンサの点群から今まで出力されていた点群の座標系は `base_link` になっていたため、点群メッセージを見てもどこのframeから発生した点群なのかの情報を後段のノードが知る由がありませんでした。
また、実際にconcat時に使われている点群は時刻同期処理をした後の点群であるため、「生点群」とconcatやそれ以降の処理点群との対応が取れないのも[一部のノード](https://github.com/autowarefoundation/autoware.universe/pull/5485)で問題になったためinterfaceの変更を提案し執り行うことにしました。

# 影響

## interfaceの利用者

localizationモジュールが主にこのinterfaceの利用者でした。syncを待つことによりlocalizationが利用できる点群の出力タイミングが微小に遅れることには留意してください。

一応、今後はconcat後の点群を使うようにする方針になったため本PRのlocalizationへの直接の影響は将来的には解消される予定です。
https://github.com/orgs/autowarefoundation/discussions/4172

## 処理負荷や遅延

今回の変更により点群の座標変換の処理が2回余計に追加され、中間topicが増えるので一部計算リソースがカツカツなprojectでは影響がある可能性があります。

ただ、社内のX2ベンチにて計算遅延を測ったときは影響は軽微でした。
https://github.com/autowarefoundation/sample_sensor_kit_launch/pull/90

# PRの分割について

aip_launcherの中身を見た結果、
xx1とx1, x2への影響はそれぞれのlauncherにて閉じているので上記の影響の調査にて別々のprojecに別々にpushすることは可能です。

- xx1へ影響するcommit
  - 7fe064e63ea502add03c7fe026996b389d9e00ac
  - 3db89268d76d4fa23ca8ab253df292969fe1cece
- x2へ影響するcommit
  - 82d3bc1fb5856b56b37e2d68d75c6fd5c4d8d403
- x1へ影響するcommit
  - 48f37db89640950997bdbd20e8df4b5b6e6ac970


![image](https://github.com/tier4/aip_launcher/assets/20086766/836b8aa3-bf54-4c22-b67d-3b46f2f9a12a)
