### PR TITLE
chore(blockage_diag): update param for aip_x2_launch

### DIFF
--- a/aip_x2_launch/config/blockage_diagnostics_param_file.yaml
+++ b/aip_x2_launch/config/blockage_diagnostics_param_file.yaml
@@ -9,3 +9,4 @@
     dust_kernel_size: 2
     dust_buffering_frames: 10
     dust_buffering_interval: 1
+    blockage_kernel: 10

--- a/aip_x2_launch/launch/lidar.launch.xml
+++ b/aip_x2_launch/launch/lidar.launch.xml
@@ -4,9 +4,9 @@
   <arg name="use_concat_filter" default="true" />
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" />
   <arg name="vehicle_mirror_param_file" />
-  <arg name="use_pointcloud_container" default="false" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
   <arg name="dual_return_filter_param_file" default="$(find-pkg-share aip_x2_launch)/config/dual_return_filter.param.yaml"/>
+  <arg name="enable_blockage_diag" default="true"/>
 
   <group>
     <push-ros-namespace namespace="lidar" />
@@ -26,6 +26,9 @@
         <arg name="return_mode" value="Strongest" />
         <arg name="min_azimuth_deg" value="135.0"/>
         <arg name="max_azimuth_deg" value="225.0"/>
+        <arg name="is_channel_order_top2down" value="true"/>
+        <arg name="horizontal_resolution" value="0.4"/>
+        <arg name="enable_blockage_diag" value="$(var enable_blockage_diag)"/>
         <arg name="calibration" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/pandar/front_lower.csv" />
         <arg name="launch_driver" value="$(var launch_driver)" />
         <arg name="dual_return_filter_param_file" value="$(var dual_return_filter_param_file)" />
@@ -46,6 +49,9 @@
         <arg name="vertical_bins" value ="64" />
         <arg name="horizontal_ring_id" value="40" />
         <arg name="return_mode" value="First" />
+        <arg name="is_channel_order_top2down" value="false"/>
+        <arg name="horizontal_resolution" value="0.6"/>
+        <arg name="enable_blockage_diag" value="$(var enable_blockage_diag)"/>
         <arg name="calibration" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/pandar/front_upper.csv" />
         <arg name="launch_driver" value="$(var launch_driver)" />
         <arg name="dual_return_filter_param_file" value="$(var dual_return_filter_param_file)" />
@@ -68,6 +74,9 @@
         <arg name="horizontal_ring_id" value="12" />
         <arg name="min_azimuth_deg" value="225.0"/>
         <arg name="max_azimuth_deg" value="315.0"/>
+        <arg name="is_channel_order_top2down" value="true"/>
+        <arg name="horizontal_resolution" value="0.4"/>
+        <arg name="enable_blockage_diag" value="$(var enable_blockage_diag)"/>
         <arg name="return_mode" value="Dual" />
         <arg name="calibration" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/pandar/left_upper.csv" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -89,6 +98,9 @@
         <arg name="distance_range" value="[0.1, 7.5]"/>
         <arg name="vertical_bins" value ="64" />
         <arg name="horizontal_ring_id" value="54" />
+        <arg name="is_channel_order_top2down" value="false"/>
+        <arg name="horizontal_resolution" value="0.6"/>
+        <arg name="enable_blockage_diag" value="$(var enable_blockage_diag)"/>
         <arg name="return_mode" value="First" />
         <arg name="calibration" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/pandar/left_lower.csv" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -112,6 +124,9 @@
         <arg name="horizontal_ring_id" value="12" />
         <arg name="min_azimuth_deg" value="45.0"/>
         <arg name="max_azimuth_deg" value="135.0"/>
+        <arg name="is_channel_order_top2down" value="true"/>
+        <arg name="horizontal_resolution" value="0.4"/>
+        <arg name="enable_blockage_diag" value="$(var enable_blockage_diag)"/>
         <arg name="return_mode" value="Dual" />
         <arg name="calibration" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/pandar/right_upper.csv" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -133,6 +148,9 @@
         <arg name="distance_range" value="[0.1, 7.5]"/>
         <arg name="vertical_bins" value ="64" />
         <arg name="horizontal_ring_id" value="54" />
+        <arg name="is_channel_order_top2down" value="false"/>
+        <arg name="horizontal_resolution" value="0.6"/>
+        <arg name="enable_blockage_diag" value="$(var enable_blockage_diag)"/>
         <arg name="return_mode" value="First" />
         <arg name="calibration" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/pandar/right_lower.csv" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -156,6 +174,9 @@
         <arg name="horizontal_ring_id" value="12" />
         <arg name="min_azimuth_deg" value="135.0"/>
         <arg name="max_azimuth_deg" value="225.0"/>
+        <arg name="is_channel_order_top2down" value="true"/>
+        <arg name="horizontal_resolution" value="0.4"/>
+        <arg name="enable_blockage_diag" value="$(var enable_blockage_diag)"/>
         <arg name="return_mode" value="Strongest" />
         <arg name="calibration" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/pandar/rear_lower.csv" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -177,6 +198,9 @@
         <arg name="distance_range" value="[0.1, 7.5]"/>
         <arg name="vertical_bins" value ="64" />
         <arg name="horizontal_ring_id" value="40" />
+        <arg name="is_channel_order_top2down" value="false"/>
+        <arg name="horizontal_resolution" value="0.6"/>
+        <arg name="enable_blockage_diag" value="$(var enable_blockage_diag)"/>
         <arg name="return_mode" value="First" />
         <arg name="calibration" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2/pandar/rear_upper.csv" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -189,8 +213,7 @@
       <arg name="base_frame" value="base_link" />
       <arg name="use_intra_process" value="true" />
       <arg name="use_multithread" value="true" />
-      <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)" />
-      <arg name="container_name" value="$(var pointcloud_container_name)"/>
+      <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
     </include>
 
   </group>

--- a/aip_x2_launch/launch/pandar_node_container.launch.py
+++ b/aip_x2_launch/launch/pandar_node_container.launch.py
@@ -43,6 +43,10 @@ def get_pandar_monitor_info():
     return p
 
 
+def str2vector(string):
+    return [float(x) for x in string.strip("[]").split(",")]
+
+
 def get_vehicle_info(context):
     # TODO(TIER IV): Use Parameter Substitution after we drop Galactic support
     # https://github.com/ros2/launch_ros/blob/master/launch_ros/launch_ros/substitutions/parameter.py
@@ -232,6 +236,7 @@ def launch_setup(context, *args, **kwargs):
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
+    distance_range = str2vector(context.perform_substitution(LaunchConfiguration("distance_range")))
     blockage_diag_component = ComposableNode(
         package="pointcloud_preprocessor",
         plugin="pointcloud_preprocessor::BlockageDiagComponent",
@@ -245,7 +250,9 @@ def launch_setup(context, *args, **kwargs):
                 "angle_range": LaunchConfiguration("angle_range"),
                 "horizontal_ring_id": LaunchConfiguration("horizontal_ring_id"),
                 "vertical_bins": LaunchConfiguration("vertical_bins"),
-                "model": LaunchConfiguration("model"),
+                "is_channel_order_top2down": LaunchConfiguration("is_channel_order_top2down"),
+                "max_distance_range": distance_range[1],
+                "horizontal_resolution": LaunchConfiguration("horizontal_resolution"),
             }
         ]
         + [load_composable_node_param("blockage_diagnostics_param_file")],
@@ -323,6 +330,7 @@ def generate_launch_description():
     add_launch_arg("input_frame", LaunchConfiguration("base_frame"))
     add_launch_arg("output_frame", LaunchConfiguration("base_frame"))
     add_launch_arg("dual_return_filter_param_file")
+    add_launch_arg("horizontal_resolution", "0.4")
     add_launch_arg(
         "blockage_diagnostics_param_file",
         [FindPackageShare("aip_x2_launch"), "/config/blockage_diagnostics_param_file.yaml"],


### PR DESCRIPTION
## Description
- This PR to add the `blockage_diag`'s params in aip_x2_launch package as some magic numbers were parameterized and individual LiDAR model was replaced by more general parameter at refactor PR: https://github.com/autowarefoundation/autoware.universe/pull/5932
- Note: There is no any change of blockage diagnostics peformance:

## Test Performed
- Tested on internal rosbag and confirmed by logging_simulator and rqt_runtime_monitor that the blockage_diag worked as expected.
[Screencast from 2024年03月19日 00時10分20秒.webm](https://github.com/tier4/aip_launcher/assets/94814556/16f614b4-ed60-49fc-9161-4be0070928a9)
