### PR TITLE
chore(blockage_diag): add option param for x2

### DIFF
--- a/aip_x2_launch/config/blockage_diagnostics_param_file.yaml
+++ b/aip_x2_launch/config/blockage_diagnostics_param_file.yaml
@@ -4,6 +4,8 @@
     blockage_count_threshold: 50
     blockage_buffering_frames: 2
     blockage_buffering_interval: 1
+    enable_dust_diag: false
+    publish_debug_image: false
     dust_ratio_threshold: 0.2
     dust_count_threshold: 10
     dust_kernel_size: 2


### PR DESCRIPTION
## Description
- Update option params for x2 which are added in PR https://github.com/autowarefoundation/autoware.universe/pull/6645
## Tests Peformed

V3.0.0ベースで[#5932](https://github.com/autowarefoundation/autoware.universe/pull/5932)と[#6645](https://github.com/autowarefoundation/autoware.universe/pull/6645)を入れた上で、テストした結果：


```
enable_dust_diag: false
publish_debug_image: false
```

![image](https://github.com/tier4/aip_launcher/assets/94814556/9d47dfd5-3926-4fce-a192-bfd74087b385)

```
enable_dust_diag: false
publish_debug_image: true
```
![image](https://github.com/tier4/aip_launcher/assets/94814556/c2913bad-3651-434d-b5b5-5b448d199ae5)

```
enable_dust_diag: true
publish_debug_image: true
```
![image](https://github.com/tier4/aip_launcher/assets/94814556/42762467-3dff-47ff-ad54-457c1e0328dd)
