### PR TITLE
chore(aip_x2): change dummy diagnostics of imu_monitor from Warn to OK

### DIFF
--- a/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -21,7 +21,7 @@
 
       # imu
       ## /sensing/imu/001-monitor
-      "imu_monitor: yaw_rate_status": { is_active: "true", status: "Warn" }
+      "imu_monitor: yaw_rate_status": default
 
       ## /sensing/imu/002-connection
       "topic_state_monitor_imu_data: imu_topic_status": default


### PR DESCRIPTION
## Related
- https://star4.slack.com/archives/CRUE57C30/p1715658549809549?thread_ts=1715658475.800439&cid=CRUE57C30
- https://github.com/tier4/aip_launcher/pull/236

## Description
Change dummy diag of imu_monitor from Warn to OK

I confirmed that there are no warnings on PSim.
![image](https://github.com/tier4/aip_launcher/assets/11865769/615254da-b6a6-4103-99c4-4c995cf4d184)
