### PR TITLE
chore(dummy_diag_publisher): add left upper visibility validation

### DIFF
--- a/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -93,3 +93,4 @@
 
       ## /others/005-visibility_validation/front_lower
       "dual_return_filter: /sensing/lidar/front_lower: visibility_validation": default
+      "dual_return_filter: /sensing/lidar/left_upper: visibility_validation": default


### PR DESCRIPTION
## Description
Related: https://github.com/tier4/autoware_launch.x2/pull/657

Added dummy diagnostics for left upper visibility validation.

Confirmed on PSim.
![image](https://github.com/tier4/aip_launcher/assets/11865769/b1c8fb08-05ca-46bc-b19d-dddb5e2be2e7)
