### PR TITLE
chore: changed the maintainers of common_sensor_launch

### DIFF
--- a/common_sensor_launch/package.xml
+++ b/common_sensor_launch/package.xml
@@ -5,7 +5,9 @@
   <version>0.1.0</version>
   <description>The common_sensor_launch package</description>
 
-  <maintainer email="hiroki.ota@tier4.jp">Hiroki OTA</maintainer>
+  <maintainer email="david.wong@tier4.jp">David Wong</maintainer>
+  <maintainer email="kenzo.lobos@tier4.jp">Kenzo Lobos-Tsunekawa</maintainer>
+  <maintainer email="max.schmeller@tier4.jp">Max Schmeller</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>


### PR DESCRIPTION
As discussed in https://github.com/tier4/aip_launcher/pull/248
I would like to change the maintainers of this package to members of the sensing team