### PR TITLE
fix: update dummy diag name

### DIFF
--- a/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -21,7 +21,7 @@
       pandar_ptp: default
       "left_upper: visibility_validation": default
       blockage_validation: default
-      concat_status: default
+      "concatenate_data: concat_status": default
 
       sensing_topic_status: default
 


### PR DESCRIPTION
Due to updated diag name of concat_status , we also update dummy diag publisher of concat_status.