### PR TITLE
chore: updated config file for the radar msg converter

### DIFF
--- a/common_sensor_launch/config/radar_tracks_msgs_converter.param.yaml
+++ b/common_sensor_launch/config/radar_tracks_msgs_converter.param.yaml
@@ -1,6 +1,7 @@
 /**:
   ros__parameters:
     update_rate_hz: 20.0
+    new_frame_id: "base_link"
     use_twist_compensation: true
     use_twist_yaw_compensation: false
     static_object_speed_threshold: 1.0


### PR DESCRIPTION
The `new_frame_id` parameter had not been added to the config file, causing the nodes to crash