### PR TITLE
refactor(common_sensor_launch, aip_x2_launch, aip_xx1_gen2_launch): radar package names

### DIFF
--- a/aip_x2_launch/launch/radar.launch.xml
+++ b/aip_x2_launch/launch/radar.launch.xml
@@ -59,7 +59,7 @@
       </include>
     </group>
 
-    <include file="$(find-pkg-share simple_object_merger)/launch/simple_object_merger.launch.xml">
+    <include file="$(find-pkg-share autoware_simple_object_merger)/launch/simple_object_merger.launch.xml">
       <arg name="output/objects" value="detected_objects"/>
       <arg name="param_path" value="$(find-pkg-share aip_x2_launch)/config/simple_object_merger.param.yaml"/>
     </include>

--- a/aip_x2_launch/package.xml
+++ b/aip_x2_launch/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
+  <exec_depend>autoware_simple_object_merger</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>dummy_diag_publisher</exec_depend>
   <exec_depend>gnss_poser</exec_depend>

--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -227,7 +227,7 @@
 
     <!-- merge radar objects -->
     <let name="merger_param_path" value="$(find-pkg-share aip_xx1_gen2_launch)/config/radar_simple_object_merger.param.yaml"/>
-    <node pkg="simple_object_merger" exec="simple_object_merger_node" name="simple_object_merger" output="screen">
+    <node pkg="autoware_simple_object_merger" exec="simple_object_merger_node" name="simple_object_merger" output="screen">
       <remap from="~/output/objects" to="detected_objects"/>
       <param from="$(var merger_param_path)"/>
     </node>

--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -56,7 +56,7 @@
           <arg name="new_plug_orientation" value="0"/>
       </include>
 
-      <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
+      <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
         <arg name="input/radar_objects" value="objects_raw"/>
         <arg name="input/odometry" value="$(var odometry_topic)"/>
         <arg name="output/radar_detected_objects" value="detected_objects"/>
@@ -88,7 +88,7 @@
           <arg name="new_plug_orientation" value="0"/>
       </include>
 
-      <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
+      <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
         <arg name="input/radar_objects" value="objects_raw"/>
         <arg name="input/odometry" value="$(var odometry_topic)"/>
         <arg name="output/radar_detected_objects" value="detected_objects"/>
@@ -120,7 +120,7 @@
           <arg name="new_plug_orientation" value="0"/>
       </include>
 
-      <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
+      <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
         <arg name="input/radar_objects" value="objects_raw"/>
         <arg name="input/odometry" value="$(var odometry_topic)"/>
         <arg name="output/radar_detected_objects" value="detected_objects"/>
@@ -152,7 +152,7 @@
           <arg name="new_plug_orientation" value="0"/>
       </include>
 
-      <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
+      <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
         <arg name="input/radar_objects" value="objects_raw"/>
         <arg name="input/odometry" value="$(var odometry_topic)"/>
         <arg name="output/radar_detected_objects" value="detected_objects"/>
@@ -184,7 +184,7 @@
           <arg name="new_plug_orientation" value="0"/>
       </include>
 
-      <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
+      <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
         <arg name="input/radar_objects" value="objects_raw"/>
         <arg name="input/odometry" value="$(var odometry_topic)"/>
         <arg name="output/radar_detected_objects" value="detected_objects"/>
@@ -216,7 +216,7 @@
           <arg name="new_plug_orientation" value="0"/>
       </include>
 
-      <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
+      <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
         <arg name="input/radar_objects" value="objects_raw"/>
         <arg name="input/odometry" value="$(var odometry_topic)"/>
         <arg name="output/radar_detected_objects" value="detected_objects"/>

--- a/aip_xx1_gen2_launch/package.xml
+++ b/aip_xx1_gen2_launch/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
+  <exec_depend>autoware_radar_tracks_msgs_converter</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>glog_component</exec_depend>
   <exec_depend>gnss_poser</exec_depend>

--- a/aip_xx1_gen2_launch/package.xml
+++ b/aip_xx1_gen2_launch/package.xml
@@ -12,6 +12,7 @@
 
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>autoware_radar_tracks_msgs_converter</exec_depend>
+  <exec_depend>autoware_simple_object_merger</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>glog_component</exec_depend>
   <exec_depend>gnss_poser</exec_depend>

--- a/common_sensor_launch/launch/ars408.launch.xml
+++ b/common_sensor_launch/launch/ars408.launch.xml
@@ -48,7 +48,7 @@
   </include>
 
   <!-- Message converter -->
-  <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
+  <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
     <arg name="input/radar_objects" value="filtered_objects"/>
     <arg name="input/odometry" value="$(var input/odometry)"/>
     <arg name="output/radar_detected_objects" value="detected_objects"/>

--- a/common_sensor_launch/launch/ars408.launch.xml
+++ b/common_sensor_launch/launch/ars408.launch.xml
@@ -40,7 +40,7 @@
   </include>
 
   <!-- Noise filter -->
-  <include file="$(find-pkg-share radar_tracks_noise_filter)/launch/radar_tracks_noise_filter.launch.xml">
+  <include file="$(find-pkg-share autoware_radar_tracks_noise_filter)/launch/radar_tracks_noise_filter.launch.xml">
     <arg name="input/tracks" value="objects_raw"/>
     <arg name="output/noise_tracks" value="noise_objects" />
     <arg name="output/filtered_tracks" value="filtered_objects" />

--- a/common_sensor_launch/package.xml
+++ b/common_sensor_launch/package.xml
@@ -13,9 +13,9 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>autoware_radar_tracks_msgs_converter</exec_depend>
+  <exec_depend>autoware_radar_tracks_noise_filter</exec_depend>
   <exec_depend>dummy_diag_publisher</exec_depend>
   <exec_depend>nebula_sensor_driver</exec_depend>
-  <exec_depend>radar_tracks_noise_filter</exec_depend>
   <exec_depend>velodyne_monitor</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/common_sensor_launch/package.xml
+++ b/common_sensor_launch/package.xml
@@ -12,9 +12,9 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <exec_depend>autoware_radar_tracks_msgs_converter</exec_depend>
   <exec_depend>dummy_diag_publisher</exec_depend>
   <exec_depend>nebula_sensor_driver</exec_depend>
-  <exec_depend>radar_tracks_msgs_converter</exec_depend>
   <exec_depend>radar_tracks_noise_filter</exec_depend>
   <exec_depend>velodyne_monitor</exec_depend>
 


### PR DESCRIPTION
## Description

This PR is to update launchers for the package name changes by PR https://github.com/autowarefoundation/autoware.universe/pull/8173

## Related links
Part of: https://github.com/autowarefoundation/autoware/issues/4569

## Test

Tested in [TIER IV Cloud](https://evaluation.tier4.jp/evaluation/reports/be58bd30-4e7b-5a73-9122-db8e5cd007d6?project_id=prd_jt) environment.