### PR TITLE
feat(aip_x1): update sensor kit calibration for pandar_xt32_front_center_base_link

### DIFF
--- a/aip_x1_description/config/sensor_kit_calibration.yaml
+++ b/aip_x1_description/config/sensor_kit_calibration.yaml
@@ -7,8 +7,8 @@ sensor_kit_base_link:
     pitch: 0.000
     yaw: 0.000
   pandar_xt32_front_center_base_link:
-    x: 1.130
-    y: 0.038
+    x: 1.800
+    y: 0.076
     z: -1.400
     roll: -0.000
     pitch: -0.00


### PR DESCRIPTION
This PR changes pandar_xt32_fron_center_base_link param  in sensor_kit_calibration.yaml

before:
![image](https://github.com/user-attachments/assets/2a22280b-41ac-4f54-b70f-9067483f940d)

after: 
![image](https://github.com/user-attachments/assets/6ff6c9ad-daa9-4dd2-864f-50108ab38648)
