### PR TITLE
fix(aip_x1): fix gnss_poser arguments in gnss.launch.xml

### DIFF
--- a/aip_x1_launch/launch/gnss.launch.xml
+++ b/aip_x1_launch/launch/gnss.launch.xml
@@ -1,27 +1,28 @@
 <launch>
 
-  <arg name="use_gnss" default="false" />
-  <arg name="launch_driver" default="true" />
+  <arg name="use_gnss" default="false"/>
+  <arg name="launch_driver" default="true"/>
 
   <group if="$(var use_gnss)">
     <push-ros-namespace namespace="gnss"/>
 
     <!-- Ublox Driver -->
     <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="1.0">
-      <remap from="~/fix" to="~/nav_sat_fix" />
+      <remap from="~/fix" to="~/nav_sat_fix"/>
       <param from="$(find-pkg-share ublox_gps)/config/c94_f9p_rover.yaml"/>
     </node>
 
     <!-- NavSatFix to MGRS Pose -->
     <include file="$(find-pkg-share gnss_poser)/launch/gnss_poser.launch.xml">
-      <arg name="input_topic_fix" value="ublox/nav_sat_fix" />
-      <arg name="input_topic_navpvt" value="ublox/navpvt" />
+      <arg name="param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x1/gnss_poser.param.yaml"/>
+      <arg name="input_topic_fix" value="ublox/nav_sat_fix"/>
 
-      <arg name="output_topic_gnss_pose" value="pose" />
-      <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance" />
-      <arg name="output_topic_gnss_fixed" value="fixed" />
+      <!-- Required only if use_ins_gnss_orientation is set to true in the param_file -->
+      <!-- <arg name="input_topic_orientation" value=""/> -->
 
-      <arg name="use_ublox_receiver" value="true" />
+      <arg name="output_topic_gnss_pose" value="pose"/>
+      <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance"/>
+      <arg name="output_topic_gnss_fixed" value="fixed"/>
     </include>
 
   </group>

--- a/aip_x1_launch/launch/gnss.launch.xml
+++ b/aip_x1_launch/launch/gnss.launch.xml
@@ -1,10 +1,12 @@
 <launch>
 
   <arg name="use_gnss" default="false"/>
-  <arg name="launch_driver" default="true"/>
 
   <group if="$(var use_gnss)">
     <push-ros-namespace namespace="gnss"/>
+
+    <arg name="launch_driver" default="true"/>
+    <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
 
     <!-- Ublox Driver -->
     <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="1.0">
@@ -14,7 +16,7 @@
 
     <!-- NavSatFix to MGRS Pose -->
     <include file="$(find-pkg-share gnss_poser)/launch/gnss_poser.launch.xml">
-      <arg name="param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x1/gnss_poser.param.yaml"/>
+      <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x1/gnss_poser.param.yaml"/>
       <arg name="input_topic_fix" value="ublox/nav_sat_fix"/>
 
       <!-- Required only if use_ins_gnss_orientation is set to true in the param_file -->

--- a/aip_x1_launch/launch/sensing.launch.xml
+++ b/aip_x1_launch/launch/sensing.launch.xml
@@ -4,7 +4,6 @@
   <arg name="vehicle_mirror_param_file" description="path to the file of vehicle mirror position yaml"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
   <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
-  <arg name="use_awsim" default="false"/>
 
   <group>
     <!-- LiDAR Driver -->
@@ -12,7 +11,6 @@
       <arg name="launch_driver" value="$(var launch_driver)" />
       <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)" />
       <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
-      <arg name="use_awsim" value="$(var use_awsim)"/>
     </include>
 
     <!-- IMU Driver -->
@@ -21,7 +19,7 @@
     </include>
 
     <!-- GNSS Driver -->
-    <include file="$(find-pkg-share aip_x1_launch)/launch/gnss.launch.xml" unless="$(var use_awsim)">
+    <include file="$(find-pkg-share aip_x1_launch)/launch/gnss.launch.xml">
       <arg name="launch_driver" value="$(var launch_driver)" />
     </include>
 


### PR DESCRIPTION
　Fixed `gnss.launch.xml` in aip_launcher for the changes in `gnss_poser.launch.xml` made by https://github.com/tier4/autoware.universe/commit/68245b31addc05ab3de53bde88755e5a70e7310b.

　This change makes aip_launcher require that `gnss_poser.param.yaml` be placed in the individual_params package ( https://github.com/tier4/autoware_individual_params.x1/pull/25 ).