### PR TITLE
chore(aip_x2): deleted as it is defined in lidar.launch.xml

### DIFF
--- a/aip_x2_launch/config/dual_return_filter.param.yaml
+++ b/aip_x2_launch/config/dual_return_filter.param.yaml
@@ -4,8 +4,6 @@
     weak_first_local_noise_threshold: 2 # description="for No_ROI roi_mode, recommended value is 10" />
     visibility_error_threshold: 0.95
     visibility_warn_threshold: 0.97
-    min_azimuth_deg: 100.0
-    max_azimuth_deg: 260.0
     max_distance: 10.0
     x_max: 18.0
     x_min: -12.0


### PR DESCRIPTION
deleted as it is defined in lidar.launch.xml. (min_azimuth_deg, max_azimuth_deg)