### PR TITLE
fix: config for awsim

### DIFF
--- a/aip_x1_launch/config/gnss_poser.param.yaml
+++ b/aip_x1_launch/config/gnss_poser.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    base_frame: base_link
+    gnss_base_frame: gnss_link
+    map_frame: map
+    buff_epoch: 1
+    use_gnss_ins_orientation: false
+    gnss_pose_pub_method: 0         # 0: Median, 1: Average

--- a/aip_x1_launch/launch/gnss.launch.xml
+++ b/aip_x1_launch/launch/gnss.launch.xml
@@ -1,10 +1,9 @@
 <launch>
 
-  <arg name="use_gnss" default="false" />
   <arg name="launch_driver" default="true" />
 
-  <group if="$(var use_gnss)">
-    <push-ros-namespace namespace="gnss"/>
+  <group>
+    <push-ros-namespace namespace="gnss" />
 
     <!-- Ublox Driver -->
     <node pkg="ublox_gps" name="ublox" exec="ublox_gps_node" if="$(var launch_driver)" respawn="true" respawn_delay="1.0">

--- a/aip_x1_launch/launch/gnss.launch.xml
+++ b/aip_x1_launch/launch/gnss.launch.xml
@@ -13,7 +13,7 @@
 
     <!-- NavSatFix to MGRS Pose -->
     <include file="$(find-pkg-share gnss_poser)/launch/gnss_poser.launch.xml">
-      <arg name="param_file" default="$(find-pkg-share aip_x1_launch)/config/gnss_poser.param.yaml" />
+      <arg name="param_file" value="$(find-pkg-share aip_x1_launch)/config/gnss_poser.param.yaml" />
       <arg name="input_topic_fix" value="ublox/nav_sat_fix" />
       <!-- Required if use_gnss_ins_orientation in gnss_poser.param.yaml is true -->
       <!-- <arg name="input_topic_orientation" value="" /> -->

--- a/aip_x1_launch/launch/gnss.launch.xml
+++ b/aip_x1_launch/launch/gnss.launch.xml
@@ -14,14 +14,13 @@
 
     <!-- NavSatFix to MGRS Pose -->
     <include file="$(find-pkg-share gnss_poser)/launch/gnss_poser.launch.xml">
+      <arg name="param_file" default="$(find-pkg-share aip_x1_launch)/config/gnss_poser.param.yaml" />
       <arg name="input_topic_fix" value="ublox/nav_sat_fix" />
-      <arg name="input_topic_navpvt" value="ublox/navpvt" />
-
+      <!-- Required if use_gnss_ins_orientation in gnss_poser.param.yaml is true -->
+      <!-- <arg name="input_topic_orientation" value="" /> -->
       <arg name="output_topic_gnss_pose" value="pose" />
       <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance" />
       <arg name="output_topic_gnss_fixed" value="fixed" />
-
-      <arg name="use_ublox_receiver" value="true" />
     </include>
 
   </group>

--- a/aip_x1_launch/launch/sensing.launch.xml
+++ b/aip_x1_launch/launch/sensing.launch.xml
@@ -20,7 +20,7 @@
     </include>
 
     <!-- GNSS Driver -->
-    <include file="$(find-pkg-share aip_x1_launch)/launch/gnss.launch.xml" unless="$(var use_awsim)">
+    <include file="$(find-pkg-share aip_x1_launch)/launch/gnss.launch.xml" if="$(var use_awsim)" >
       <arg name="launch_driver" value="$(var launch_driver)" />
     </include>
 

--- a/aip_x1_launch/launch/sensing.launch.xml
+++ b/aip_x1_launch/launch/sensing.launch.xml
@@ -12,7 +12,6 @@
       <arg name="launch_driver" value="$(var launch_driver)" />
       <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)" />
       <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
-      <arg name="use_awsim" value="$(var use_awsim)"/>
     </include>
 
     <!-- IMU Driver -->

--- a/aip_x1_launch/package.xml
+++ b/aip_x1_launch/package.xml
@@ -10,14 +10,14 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>autoware_compare_map_segmentation</exec_depend>
   <exec_depend>autoware_elevation_map_loader</exec_depend>
   <exec_depend>autoware_ground_segmentation</exec_depend>
-  <exec_depend>imu_corrector</exec_depend>
-  <exec_depend>individual_params</exec_depend>
   <exec_depend>autoware_occupancy_grid_map_outlier_filter</exec_depend>
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
+  <exec_depend>common_sensor_launch</exec_depend>
+  <exec_depend>imu_corrector</exec_depend>
+  <exec_depend>individual_params</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>ros2_socketcan</exec_depend>
   <exec_depend>tamagawa_imu_driver</exec_depend>

--- a/aip_x2_launch/package.xml
+++ b/aip_x2_launch/package.xml
@@ -10,11 +10,11 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>dummy_diag_publisher</exec_depend>
   <exec_depend>gnss_poser</exec_depend>
   <exec_depend>imu_corrector</exec_depend>
-  <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>septentrio_gnss_driver</exec_depend>
   <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/aip_xx1_gen2_launch/package.xml
+++ b/aip_xx1_gen2_launch/package.xml
@@ -10,12 +10,12 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>glog_component</exec_depend>
   <exec_depend>gnss_poser</exec_depend>
   <exec_depend>imu_corrector</exec_depend>
   <exec_depend>pacmod3</exec_depend>
-  <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>ros2_socketcan</exec_depend>
   <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/aip_xx1_launch/package.xml
+++ b/aip_xx1_launch/package.xml
@@ -10,12 +10,12 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>glog_component</exec_depend>
   <exec_depend>gnss_poser</exec_depend>
   <exec_depend>imu_corrector</exec_depend>
   <exec_depend>pacmod3</exec_depend>
-  <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>ros2_socketcan</exec_depend>
   <exec_depend>tamagawa_imu_driver</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/common_sensor_launch/package.xml
+++ b/common_sensor_launch/package.xml
@@ -10,10 +10,10 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <exec_depend>dummy_diag_publisher</exec_depend>
-  <exec_depend>nebula_sensor_driver</exec_depend>
   <exec_depend>autoware_radar_tracks_msgs_converter</exec_depend>
   <exec_depend>autoware_radar_tracks_noise_filter</exec_depend>
+  <exec_depend>dummy_diag_publisher</exec_depend>
+  <exec_depend>nebula_sensor_driver</exec_depend>
   <exec_depend>velodyne_monitor</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
このPRには以下の変更が含まれます。

- `lidar.launch.xml` に渡すパラメータの修正
`lidar.launch.xml` に使われていないパラメータ `use_awsim` が渡されていたため、その行を削除

- `gnss_poser` のパラメータ修正
`gnss_poser` パッケージに含まれるデフォルトのコンフィグファイルは `gnss_base_frame` が `gnss_base_link` となっているなど、現状のX1のものと異なっていたためX1用のコンフィグファイルを追加し、それを利用するようにしました

- GNSS関連の起動条件修正
従来の「AWSIMでも実機でも起動しない」条件を「AWSIMのときのみ起動する」条件に変更。
これにより、`NavSatFix` -> `PoseWithCovariance` の変換がAWSIM実行時にも動作するため、eagleye利用時と非利用時でAWSIMのバイナリを分ける必要がなくなります。
  - 変更前
eagleye非利用時： AWSIM -> `(PoseWithCovarianceMsg)` -> `ekf_localizer`
eagleye利用時： AWSIM -> `(NavSatFixMsg)` -> `eagleye`
  - 変更後
eagleye非利用時： AWSIM -> `(NavSatFixMsg)` -> `gnss_poser` -> `(PoseWithCovarianceMsg)` -> `ekf_localizer`
eagleye利用時： AWSIM -> `(NavSatFixMsg)` -> `eagleye`


備考：
　パラメータの意味としては、 `use_awsim` パラメータの名前を `use_gnss` パラメータに変更し、`autoware_launch.x1` パッケージ側で[AWSIM使うかどうか → GNSS起動是非の判断]をするべきですが、`autoware_launch.x1` 側の修正と同時に行う必要があるため、一旦このままにしています。