### PR TITLE
feat: update dummy diag publisher config

### DIFF
--- a/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -13,20 +13,59 @@
   ros__parameters:
     required_diags:
       # gnss
-      gnss: default
+      "topic_state_monitor_gnss_pose: gnss_topic_status": default
+      "septentrio_driver: Quality indicators": default
 
       # imu
-      yaw_rate_status: default
+      "imu_monitor: yaw_rate_status": default
+      "topic_state_monitor_imu_data: imu_topic_status": default
+      "gyro_bias_validator: gyro_bias_validator": default
 
       # lidar
-      pandar_connection: default
-      pandar_temperature: default
-      pandar_ptp: default
-      "left_upper: visibility_validation": default
-      blockage_validation: default
+      "pandar_monitor: /sensing/lidar/front_lower: pandar_connection": default
+      "pandar_monitor: /sensing/lidar/front_upper: pandar_connection": default
+      "pandar_monitor: /sensing/lidar/left_lower: pandar_connection": default
+      "pandar_monitor: /sensing/lidar/left_upper: pandar_connection": default
+      "pandar_monitor: /sensing/lidar/right_lower: pandar_connection": default
+      "pandar_monitor: /sensing/lidar/right_upper: pandar_connection": default
+      "pandar_monitor: /sensing/lidar/rear_lower: pandar_connection": default
+      "pandar_monitor: /sensing/lidar/rear_upper: pandar_connection": default
+
+      "pandar_monitor: /sensing/lidar/front_lower: pandar_ptp": default
+      "pandar_monitor: /sensing/lidar/front_upper: pandar_ptp": default
+      "pandar_monitor: /sensing/lidar/left_lower: pandar_ptp": default
+      "pandar_monitor: /sensing/lidar/left_upper: pandar_ptp": default
+      "pandar_monitor: /sensing/lidar/right_lower: pandar_ptp": default
+      "pandar_monitor: /sensing/lidar/right_upper: pandar_ptp": default
+      "pandar_monitor: /sensing/lidar/rear_lower: pandar_ptp": default
+      "pandar_monitor: /sensing/lidar/rear_upper: pandar_ptp": defaultlt
+
+      "pandar_monitor: /sensing/lidar/front_lower: pandar_temperature": default
+      "pandar_monitor: /sensing/lidar/front_upper: pandar_temperature": default
+      "pandar_monitor: /sensing/lidar/left_lower: pandar_temperature": default
+      "pandar_monitor: /sensing/lidar/left_upper: pandar_temperature": default
+      "pandar_monitor: /sensing/lidar/right_lower: pandar_temperature": default
+      "pandar_monitor: /sensing/lidar/right_upper: pandar_temperature": default
+      "pandar_monitor: /sensing/lidar/rear_lower: pandar_temperature": default
+      "pandar_monitor: /sensing/lidar/rear_upper: pandar_temperature": default
       "concatenate_data: concat_status": default
 
-      sensing_topic_status: default
+      # camera
+      "v4l2_camera_camera0: capture_status": default
+      "v4l2_camera_camera1: capture_status": default
+      "v4l2_camera_camera2: capture_status": default
+      "v4l2_camera_camera3: capture_status": default
+      "v4l2_camera_camera4: capture_status": default
+      "v4l2_camera_camera5: capture_status": default
+      "v4l2_camera_camera6: capture_status": default
+      "v4l2_camera_camera7: capture_status": default
 
-      # imu
-      gyro_bias_estimator: default
+      # radar
+      "topic_state_monitor_radar_front_center: radar_front_center_topic_status": default
+      "topic_state_monitor_radar_front_left: radar_front_left_topic_status": default
+      "topic_state_monitor_radar_front_right: radar_front_right_topic_status": default
+      "topic_state_monitor_radar_rear_center: radar_rear_center_topic_status": default
+      "topic_state_monitor_radar_rear_left: radar_rear_left_topic_status": default
+      "topic_state_monitor_radar_rear_right: radar_rear_right_topic_status": default
+
+

--- a/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -67,5 +67,3 @@
       "topic_state_monitor_radar_rear_center: radar_rear_center_topic_status": default
       "topic_state_monitor_radar_rear_left: radar_rear_left_topic_status": default
       "topic_state_monitor_radar_rear_right: radar_rear_right_topic_status": default
-
-


### PR DESCRIPTION
After enabling MRM for sensing diag, we need to configure dummy diag publisher as well.
I prepare the config for x2/beta/v3.1.0 .

Test result with PSim
![image](https://github.com/user-attachments/assets/90c5dd18-46f3-4405-aa3e-f81680141c58)
