### PR TITLE
fix: gnss antenna

### DIFF
--- a/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
+++ b/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
@@ -15,9 +15,9 @@
       heading: 0.0
       pitch: 0.0
 
-    ant_type: "AERAT1675_382 NONE"
+    ant_type: "SEPPOLANT_MC.V2 NONE"
     ant_serial_nr: Unknown
-    ant_aux1_type: "AERAT1675_382 NONE"
+    ant_aux1_type: "SEPPOLANT_MC.V2 NONE"
     ant_aux1_serial_nr: Unknown
 
     polling_period:


### PR DESCRIPTION
## Description
X2 gen2で使用するGNSS受信機(Septentrio AsteRx SB3 Pro)のアンテナ設定の修正PRです。[RT0-31485](https://tier4.atlassian.net/browse/RT0-31485)
## Tests performed
x2 gen2ベンチにて、autoware起動後にGNSS受信機の設定画面を開き、適切に設定されていることを確認した。

![Screenshot from 2024-09-13 14-13-29](https://github.com/user-attachments/assets/3cab25f7-9848-4db0-8242-acb06f5ab6fa)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/

[RT0-31485]: https://tier4.atlassian.net/browse/RT0-31485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ