### PR TITLE
chore(aip_x2_launch): use `radar_monitor` instead of `pe_ars408_ros`

### DIFF
--- a/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -71,12 +71,12 @@
       "v4l2_camera_camera7: capture_status": default
 
       ## /sensing/radar/001-connection
-      "topic_state_monitor_radar_front_center: radar_front_center_topic_status": default
-      "topic_state_monitor_radar_front_left: radar_front_left_topic_status": default
-      "topic_state_monitor_radar_front_right: radar_front_right_topic_status": default
-      "topic_state_monitor_radar_rear_center: radar_rear_center_topic_status": default
-      "topic_state_monitor_radar_rear_left: radar_rear_left_topic_status": default
-      "topic_state_monitor_radar_rear_right: radar_rear_right_topic_status": default
+      "radar_monitor: /sensing/radar/front_center: radar_status": default
+      "radar_monitor: /sensing/radar/front_left: radar_status": default
+      "radar_monitor: /sensing/radar/front_right: radar_status": default
+      "radar_monitor: /sensing/radar/rear_center: radar_status": default
+      "radar_monitor: /sensing/radar/rear_left: radar_status": default
+      "radar_monitor: /sensing/radar/rear_right: radar_status": default
 
       ## /others/002-blockage_validation
       "blockage_return_diag: /sensing/lidar/front_lower: blockage_validation": default

--- a/aip_x2_launch/launch/radar.launch.xml
+++ b/aip_x2_launch/launch/radar.launch.xml
@@ -7,7 +7,7 @@
 
     <group>
       <push-ros-namespace namespace="front_center" />
-      <include file="$(find-pkg-share common_sensor_launch)/launch/ars408.launch.xml">
+      <include file="$(find-pkg-share radar_monitor)/launch/radar_monitor.launch.xml">
         <arg name="interface" value="pcan2"/>
         <arg name="output_frame" value="front_center/radar_link" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -16,7 +16,7 @@
 
     <group>
       <push-ros-namespace namespace="front_left" />
-      <include file="$(find-pkg-share common_sensor_launch)/launch/ars408.launch.xml">
+      <include file="$(find-pkg-share radar_monitor)/launch/radar_monitor.launch.xml">
         <arg name="interface" value="pcan3"/>
         <arg name="output_frame" value="front_left/radar_link" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -25,7 +25,7 @@
 
     <group>
       <push-ros-namespace namespace="rear_left" />
-      <include file="$(find-pkg-share common_sensor_launch)/launch/ars408.launch.xml">
+      <include file="$(find-pkg-share radar_monitor)/launch/radar_monitor.launch.xml">
         <arg name="interface" value="pcan4"/>
         <arg name="output_frame" value="rear_left/radar_link" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -34,7 +34,7 @@
 
     <group>
       <push-ros-namespace namespace="rear_center" />
-      <include file="$(find-pkg-share common_sensor_launch)/launch/ars408.launch.xml">
+      <include file="$(find-pkg-share radar_monitor)/launch/radar_monitor.launch.xml">
         <arg name="interface" value="pcan5"/>
         <arg name="output_frame" value="rear_center/radar_link" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -43,7 +43,7 @@
 
     <group>
       <push-ros-namespace namespace="rear_right" />
-      <include file="$(find-pkg-share common_sensor_launch)/launch/ars408.launch.xml">
+      <include file="$(find-pkg-share radar_monitor)/launch/radar_monitor.launch.xml">
         <arg name="interface" value="pcan6"/>
         <arg name="output_frame" value="rear_right/radar_link" />
         <arg name="launch_driver" value="$(var launch_driver)" />
@@ -52,20 +52,12 @@
 
     <group>
       <push-ros-namespace namespace="front_right" />
-      <include file="$(find-pkg-share common_sensor_launch)/launch/ars408.launch.xml">
+      <include file="$(find-pkg-share radar_monitor)/launch/radar_monitor.launch.xml">
         <arg name="interface" value="pcan7"/>
         <arg name="output_frame" value="front_right/radar_link" />
         <arg name="launch_driver" value="$(var launch_driver)" />
       </include>
     </group>
-
-    <include file="$(find-pkg-share simple_object_merger)/launch/simple_object_merger.launch.xml">
-      <arg name="output/objects" value="detected_objects"/>
-      <arg name="update_rate_hz" value="20.0"/>
-      <arg name="new_frame_id" value="base_link"/>
-      <arg name="timeout_threshold" value="1.0"/>
-      <arg name="input_topics" value="[/sensing/radar/front_center/detected_objects, /sensing/radar/front_left/detected_objects, /sensing/radar/rear_left/detected_objects, /sensing/radar/rear_center/detected_objects, /sensing/radar/rear_right/detected_objects, /sensing/radar/front_right/detected_objects]"/>
-    </include>
 
   </group>
 </launch>

--- a/aip_x2_launch/launch/topic_state_monitor.launch.py
+++ b/aip_x2_launch/launch/topic_state_monitor.launch.py
@@ -58,121 +58,6 @@ def generate_launch_description():
         extra_arguments=[{"use_intra_process_comms": True}],
     )
 
-    # Radar topic monitors
-    radar_front_center_monitor = ComposableNode(
-        package="topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_front_center",
-        parameters=[
-            {
-                "topic": "/sensing/radar/front_center/objects_raw",
-                "topic_type": "radar_msgs/msg/RadarTracks",
-                "best_effort": True,
-                "diag_name": "radar_front_center_topic_status",
-                "warn_rate": 5.0,
-                "error_rate": 1.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_front_left_monitor = ComposableNode(
-        package="topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_front_left",
-        parameters=[
-            {
-                "topic": "/sensing/radar/front_left/objects_raw",
-                "topic_type": "radar_msgs/msg/RadarTracks",
-                "best_effort": True,
-                "diag_name": "radar_front_left_topic_status",
-                "warn_rate": 5.0,
-                "error_rate": 1.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_front_right_monitor = ComposableNode(
-        package="topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_front_right",
-        parameters=[
-            {
-                "topic": "/sensing/radar/front_right/objects_raw",
-                "topic_type": "radar_msgs/msg/RadarTracks",
-                "best_effort": True,
-                "diag_name": "radar_front_right_topic_status",
-                "warn_rate": 5.0,
-                "error_rate": 1.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_rear_center_monitor = ComposableNode(
-        package="topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_rear_center",
-        parameters=[
-            {
-                "topic": "/sensing/radar/rear_center/objects_raw",
-                "topic_type": "radar_msgs/msg/RadarTracks",
-                "best_effort": True,
-                "diag_name": "radar_rear_center_topic_status",
-                "warn_rate": 5.0,
-                "error_rate": 1.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_rear_left_monitor = ComposableNode(
-        package="topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_rear_left",
-        parameters=[
-            {
-                "topic": "/sensing/radar/rear_left/objects_raw",
-                "topic_type": "radar_msgs/msg/RadarTracks",
-                "best_effort": True,
-                "diag_name": "radar_rear_left_topic_status",
-                "warn_rate": 5.0,
-                "error_rate": 1.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_rear_right_monitor = ComposableNode(
-        package="topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_rear_right",
-        parameters=[
-            {
-                "topic": "/sensing/radar/rear_right/objects_raw",
-                "topic_type": "radar_msgs/msg/RadarTracks",
-                "best_effort": True,
-                "diag_name": "radar_rear_right_topic_status",
-                "warn_rate": 5.0,
-                "error_rate": 1.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
     # ComposableNodeContainer to run all ComposableNodes
     container = ComposableNodeContainer(
         name="topic_state_monitor_container",
@@ -182,12 +67,6 @@ def generate_launch_description():
         composable_node_descriptions=[
             gnss_topic_monitor,
             imu_topic_monitor,
-            radar_front_center_monitor,
-            radar_front_left_monitor,
-            radar_front_right_monitor,
-            radar_rear_center_monitor,
-            radar_rear_left_monitor,
-            radar_rear_right_monitor,
         ],
         output="screen",
     )


### PR DESCRIPTION
### Description
- Replace `pe_ars408_ros` with `radar_monitor`

### Related Lionk
- https://github.com/tier4/l4_toolkit/pull/22
- https://github.com/tier4/autoware_launch.x2/pull/803
- https://tier4.atlassian.net/browse/RT0-33356