### PR TITLE
chore(nebula_node_container): fix, confirm and re-enable ring_outlier_filter

### DIFF
--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -22,7 +22,8 @@ from launch.actions import SetLaunchConfiguration
 
 # from launch.conditions import LaunchConfigurationNotEquals
 from launch.conditions import IfCondition
-from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals
+from launch.conditions import LaunchConfigurationEquals
+from launch.conditions import LaunchConfigurationNotEquals
 from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer


### PR DESCRIPTION
This PR re-enables the `ring_outlier_filter` in `nebula_node_container.launch.py` which was previously disabled in:

- #310 

The module is working (= outputting pointclouds at 10 Hz and not crashing) on my Desktop with one OT128 and one QT128 connected, with the current pilot-auto.x2.

Here are the versions used:
- [pilot-auto.x2@1a0a491](https://github.com/tier4/pilot-auto.x2/blob/1a0a491c033e941acc6b8d67aa052eff71174375)
- [autoware.universe@a71b2d5](https://github.com/autowarefoundation/autoware.universe/blob/a71b2d5ab60c6f7c230aca960dc63a642675c62b)
- [nebula@81afef9](https://github.com/tier4/nebula/blob/81afef9ec1cdc1dae9d39e08e916813baab1fd4c)
- [autowarefoundation/transport_drivers@8a93ae0](https://github.com/autowarefoundation/transport_drivers/blob/1a0a491c033e941acc6b8d67aa052eff71174375)
- [autowarefoundation/ros2_socketcan@2bbdba4](https://github.com/autowarefoundation/ros2_socketcan/blob/1a0a491c033e941acc6b8d67aa052eff71174375)