### PR TITLE
fix: make sync angle and cutting angle same as gen1

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -33,7 +33,7 @@
         <arg name="sensor_ip" value="192.168.1.202"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2321"/>
-        <arg name="sync_angle" value="90"/>
+        <arg name="sync_angle" value="0"/>
         <arg name="cut_angle" value="274.0" />
         <arg name="cloud_min_angle" value="88"/>
         <arg name="cloud_max_angle" value="274"/>
@@ -66,7 +66,7 @@
         <arg name="sensor_ip" value="192.168.1.203"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2322"/>
-        <arg name="sync_angle" value="0"/>
+        <arg name="sync_angle" value="270"/>
         <arg name="cut_angle" value="0.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="0"/>
@@ -99,7 +99,7 @@
         <arg name="sensor_ip" value="192.168.1.212"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2376"/>
-        <arg name="sync_angle" value="90"/>
+        <arg name="sync_angle" value="0"/>
         <arg name="cut_angle" value="270.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
@@ -132,7 +132,7 @@
         <arg name="sensor_ip" value="192.168.1.213"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2377"/>
-        <arg name="sync_angle" value="0"/>
+        <arg name="sync_angle" value="270"/>
         <arg name="cut_angle" value="270.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
@@ -166,7 +166,7 @@
         <arg name="sensor_ip" value="192.168.1.204"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2323"/>
-        <arg name="sync_angle" value="270"/>
+        <arg name="sync_angle" value="180"/>
         <arg name="cut_angle" value="277.0" />
         <arg name="cloud_min_angle" value="97"/>
         <arg name="cloud_max_angle" value="277"/>
@@ -199,7 +199,7 @@
         <arg name="sensor_ip" value="192.168.1.205"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2324"/>
-        <arg name="sync_angle" value="180"/>
+        <arg name="sync_angle" value="90"/>
         <arg name="cut_angle" value="270.0" />
         <arg name="cloud_min_angle" value="0"/>
         <arg name="cloud_max_angle" value="270"/>
@@ -232,7 +232,7 @@
         <arg name="sensor_ip" value="192.168.1.214"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2378"/>
-        <arg name="sync_angle" value="270"/>
+        <arg name="sync_angle" value="180"/>
         <arg name="cut_angle" value="270.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
@@ -265,7 +265,7 @@
         <arg name="sensor_ip" value="192.168.1.215"/>
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2379"/>
-        <arg name="sync_angle" value="180"/>
+        <arg name="sync_angle" value="90"/>
         <arg name="cut_angle" value="270.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>

--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -34,7 +34,7 @@
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2321"/>
         <arg name="sync_angle" value="0"/>
-        <arg name="cut_angle" value="274.0" />
+        <arg name="cut_angle" value="180.0" />
         <arg name="cloud_min_angle" value="88"/>
         <arg name="cloud_max_angle" value="274"/>
         <arg name="return_mode" value="LastStrongest"/>
@@ -100,7 +100,7 @@
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2376"/>
         <arg name="sync_angle" value="0"/>
-        <arg name="cut_angle" value="270.0" />
+        <arg name="cut_angle" value="180.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
         <arg name="return_mode" value="LastStrongest"/>


### PR DESCRIPTION
## Description
Sync angle, Cut angleをGen1と同様の設定になるよう修正

## Related
- https://tier4.atlassian.net/wiki/spaces/SI/pages/3176498404/X2+2024-06-24+X2+gen2+LiDAR+settings+FOV+Return+mode
- https://tier4.atlassian.net/wiki/spaces/KB4FAE/pages/2780074364/LiDAR+IP+J6
  - setting in Gen1