### PR TITLE
fix: use ring_outlier_filter_node_param

### DIFF
--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -25,8 +25,8 @@ from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
-from launch_ros.substitutions import FindPackageShare
 from launch_ros.parameter_descriptions import ParameterFile
+from launch_ros.substitutions import FindPackageShare
 import yaml
 
 
@@ -223,9 +223,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     ring_outlier_filter_node_param = ParameterFile(
-        param_file=LaunchConfiguration("ring_outlier_filter_node_param_file").perform(
-            context
-        ),
+        param_file=LaunchConfiguration("ring_outlier_filter_node_param_file").perform(context),
         allow_substs=True,
     )
 

--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -26,6 +26,7 @@ from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
+from launch_ros.parameter_descriptions import ParameterFile
 import yaml
 
 
@@ -221,13 +222,20 @@ def launch_setup(context, *args, **kwargs):
         )
     )
 
+    ring_outlier_filter_node_param = ParameterFile(
+        param_file=LaunchConfiguration("ring_outlier_filter_node_param_file").perform(
+            context
+        ),
+        allow_substs=True,
+    )
+
     # Ring Outlier Filter is the last component in the pipeline, so control the output frame here
-    if LaunchConfiguration("output_as_sensor_frame").perform(context):
-        ring_outlier_filter_parameters = {"output_frame": LaunchConfiguration("frame_id")}
+    if LaunchConfiguration("output_as_sensor_frame").perform(context).lower() == "true":
+        ring_outlier_output_frame = {"output_frame": LaunchConfiguration("frame_id")}
     else:
-        ring_outlier_filter_parameters = {
-            "output_frame": ""
-        }  # keep the output frame as the input frame
+        # keep the output frame as the input frame
+        ring_outlier_output_frame = {"output_frame": ""}
+
     nodes.append(
         ComposableNode(
             package="autoware_pointcloud_preprocessor",
@@ -237,7 +245,7 @@ def launch_setup(context, *args, **kwargs):
                 ("input", "rectified/pointcloud_ex"),
                 ("output", "pointcloud_before_sync"),
             ],
-            parameters=[ring_outlier_filter_parameters],
+            parameters=[ring_outlier_filter_node_param, ring_outlier_output_frame],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )
     )


### PR DESCRIPTION
The pull request below added `ring_outlier_filter_node_param_file`, but it doesn't seem to be loaded properly.
https://github.com/tier4/aip_launcher/pull/305

This pull request fixes the above issue.

## How tested
I have confirmed that the following script works properly.

`$HOME/Downloads/odaiba_urp_binary_2024_09_11/AWSIM.x86_64` is [TIER IV internal AWSIM](https://drive.google.com/file/d/1i10ywoSIbtWLJVYqk3T5Lh6bnicL8BGF/view).

The map is also [TIER IV internal](https://evaluation.tier4.jp/evaluation/maps/335?project_id=prd_jt).

The branch of pilot-auto is beta/v0.36 <https://github.com/tier4/pilot-auto/tree/beta/v0.36>.

```bash
#!/bin/bash
set -eux

trap "kill 0" EXIT

set +eux
source $HOME/pilot-auto/install/setup.bash
set -eux

$HOME/Downloads/odaiba_urp_binary_2024_09_11/AWSIM.x86_64 &

ros2 launch autoware_launch e2e_simulator.launch.xml \
    map_path:=$HOME/autoware_map/odaiba_beta/ \
    vehicle_model:=taxi \
    sensor_model:=aip_xx1 \
    use_foa:=false \
    vehicle_id:=awsim_jpt \
    traffic_light_namespace:=[camera6]
```
