### PR TITLE
fix: pass launch_driver argument

### DIFF
--- a/aip_x2_gen2_launch/launch/hesai_OT128.launch.xml
+++ b/aip_x2_gen2_launch/launch/hesai_OT128.launch.xml
@@ -32,7 +32,7 @@
   <arg name="blockage_diagnostics_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/blockage_diagnostics_param_file.yaml" />
 
   <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/nebula_node_container.launch.py">
-    <arg name="launch_driver" value="$(var launch_driver)"/>
+    <arg name="launch_hw" value="$(var launch_driver)"/>
     <arg name="sensor_model" value="$(var model)"/>
     <arg name="return_mode" value="$(var return_mode)"/>
     <arg name="frame_id" value="$(var sensor_frame)"/>

--- a/aip_x2_gen2_launch/launch/hesai_QT128.launch.xml
+++ b/aip_x2_gen2_launch/launch/hesai_QT128.launch.xml
@@ -33,7 +33,7 @@
   <arg name="blockage_diagnostics_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/blockage_diagnostics_param_file.yaml" />
 
   <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/nebula_node_container.launch.py">
-    <arg name="launch_driver" value="$(var launch_driver)"/>
+    <arg name="launch_hw" value="$(var launch_driver)"/>
     <arg name="sensor_model" value="$(var model)"/>
     <arg name="return_mode" value="$(var return_mode)"/>
     <arg name="frame_id" value="$(var sensor_frame)"/>

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -119,7 +119,7 @@ def launch_setup(context, *args, **kwargs):
                     "ptp_domain",
                     "diag_span",
                     "calibration_file",
-                    "launch_hw"
+                    "launch_hw",
                 ),
                 "retry_hw": True,
             },

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -119,8 +119,8 @@ def launch_setup(context, *args, **kwargs):
                     "ptp_domain",
                     "diag_span",
                     "calibration_file",
+                    "launch_hw"
                 ),
-                "launch_hw": True,
                 "retry_hw": True,
             },
         ],
@@ -318,7 +318,7 @@ def generate_launch_description():
 
     add_launch_arg("sensor_model", description="sensor model name")
     add_launch_arg("config_file", "", description="sensor configuration file")
-    add_launch_arg("launch_driver", "True", "do launch driver")
+    add_launch_arg("launch_hw", "True", "do launch driver")
     add_launch_arg("setup_sensor", "True", "configure sensor")
     add_launch_arg("sensor_ip", "192.168.1.201", "device ip address")
     add_launch_arg(


### PR DESCRIPTION
## Description
Fixed to pass `launch_driver` argument to nebula driver.

## Tests performed

Launched Autoware by this command, and confirmed pointcloud are published. 
```
VEHICLE_ID=j6_gen2_01 ros2 launch autoware_launch logging_simulator.launch.xml map_path:=[path_to_map] pointcloud_map_file:=pcd vehicle_model:=j6_gen2 sensor_model:=aip_x2_gen2 
```

![image](https://github.com/user-attachments/assets/98dd3468-dcd4-4498-9d03-837abdd721f5)
