### PR TITLE
fix: fov for front_upper lidar

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -170,7 +170,7 @@
         <arg name="data_port" value="2323"/>
         <arg name="sync_angle" value="180"/>
         <arg name="cut_angle" value="277.0" />
-        <arg name="cloud_min_angle" value="97"/>
+        <arg name="cloud_min_angle" value="83"/>
         <arg name="cloud_max_angle" value="277"/>
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="ptp_profile" value="automotive"/>


### PR DESCRIPTION
## Description
Fixed FoV settinsg for Front Upper LiDAR.

Related:
- https://star4.slack.com/archives/CRUE57C30/p1728951319784869?thread_ts=1728635356.905419&cid=CRUE57C30
- https://tier4.atlassian.net/wiki/spaces/SI/pages/3176498404/X2+2024-06-24+X2+gen2+LiDAR+settings+FOV+Return+mode#FOV
