### PR TITLE
feat(aip_x2_gen2_launch): add launcher for ARS548 to pass some missing arguments

### DIFF
--- a/aip_x2_gen2_launch/config/ARS548.param.yaml
+++ b/aip_x2_gen2_launch/config/ARS548.param.yaml
@@ -1,0 +1,17 @@
+/**:
+  ros__parameters:
+    host_ip: 10.13.1.166
+    sensor_ip: 10.13.1.114
+    data_port: 42102
+    base_frame: base_link
+    object_frame: base_link
+    launch_hw: true
+    multicast_ip: 224.0.2.2
+    sensor_model: ARS548
+    configuration_host_port: 42401
+    configuration_sensor_port: 42101
+    use_sensor_time: false
+    configuration_vehicle_length: 7.2369
+    configuration_vehicle_width: 2.2916
+    configuration_vehicle_height: 3.08
+    configuration_vehicle_wheelbase: 4.76012

--- a/aip_x2_gen2_launch/launch/ars548.launch.xml
+++ b/aip_x2_gen2_launch/launch/ars548.launch.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<launch>
+    <arg name="sensor_model" default="ARS548"/>
+    <arg name="launch_hw" default="true" description="Whether to connect to a real sensor (true) or to accept packet messages (false)."/>
+    <arg name="config_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/ARS548.param.yaml"/>
+    <arg name="frame_id"/>
+    <arg name="sensor_ip"/>
+    <arg name="odometry_topic"/>
+    <arg name="acceleration_topic"/>
+    <arg name="steering_angle_topic"/>
+
+    <node pkg="nebula_ros" exec="continental_ars548_ros_wrapper_node" name="nebula_continental_ars548" output="screen">
+        <param from="$(var config_file)" allow_substs="true"/>
+        <param name="launch_hw" value="$(var launch_hw)"/>
+        <param name="frame_id" value="$(var frame_id)"/>
+        <param name="sensor_ip" value="$(var sensor_ip)"/>
+        <remap from="odometry_input" to="$(var odometry_topic)"/>
+        <remap from="acceleration_input" to="$(var acceleration_topic)"/>
+        <remap from="steering_angle_input" to="$(var steering_angle_topic)"/>
+        <remap from="diagnostics" to="/diagnostics"/>
+    </node>
+
+</launch>

--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -28,8 +28,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-
-        <arg name="new_plug_orientation" value="0"/>
       </include>
 
 
@@ -61,8 +59,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-
-        <arg name="new_plug_orientation" value="0"/>
       </include>
 
       <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
@@ -93,8 +89,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-
-        <arg name="new_plug_orientation" value="0"/>
       </include>
 
       <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
@@ -125,8 +119,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-
-        <arg name="new_plug_orientation" value="0"/>
       </include>
 
       <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
@@ -157,8 +149,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-
-        <arg name="new_plug_orientation" value="0"/>
       </include>
 
       <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
@@ -189,8 +179,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-
-        <arg name="new_plug_orientation" value="0"/>
       </include>
 
       <include file="$(find-pkg-share radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">

--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -16,10 +16,11 @@
 
     <group>
       <push-ros-namespace namespace="front_center"/>
-      <include file="$(find-pkg-share nebula_ros)/launch/continental_launch_all_hw.xml" if="$(var launch_driver)">
+      <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/ars548.launch.xml">
         <arg name="odometry_topic" value="$(var odometry_topic)"/>
         <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
         <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+        <arg name="launch_hw" value="$(var launch_driver)"/>
 
         <arg name="sensor_ip" value="10.13.1.114"/>
         <arg name="frame_id" value="front_center/radar_link"/>
@@ -48,11 +49,11 @@
 
     <group>
       <push-ros-namespace namespace="front_left"/>
-      <include file="$(find-pkg-share nebula_ros)/launch/continental_launch_all_hw.xml" if="$(var launch_driver)">
-
+      <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/ars548.launch.xml">
         <arg name="odometry_topic" value="$(var odometry_topic)"/>
         <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
         <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+        <arg name="launch_hw" value="$(var launch_driver)"/>
 
         <arg name="sensor_ip" value="10.13.1.115"/>
         <arg name="frame_id" value="front_left/radar_link"/>
@@ -80,11 +81,11 @@
 
     <group>
       <push-ros-namespace namespace="front_right"/>
-      <include file="$(find-pkg-share nebula_ros)/launch/continental_launch_all_hw.xml" if="$(var launch_driver)">
-
+      <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/ars548.launch.xml">
         <arg name="odometry_topic" value="$(var odometry_topic)"/>
         <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
         <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+        <arg name="launch_hw" value="$(var launch_driver)"/>
 
         <arg name="sensor_ip" value="10.13.1.116"/>
         <arg name="frame_id" value="front_right/radar_link"/>
@@ -112,10 +113,11 @@
 
     <group>
       <push-ros-namespace namespace="rear_center"/>
-      <include file="$(find-pkg-share nebula_ros)/launch/continental_launch_all_hw.xml" if="$(var launch_driver)">
+      <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/ars548.launch.xml">
         <arg name="odometry_topic" value="$(var odometry_topic)"/>
         <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
         <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+        <arg name="launch_hw" value="$(var launch_driver)"/>
 
         <arg name="sensor_ip" value="10.13.1.117"/>
         <arg name="frame_id" value="rear_center/radar_link"/>
@@ -143,10 +145,11 @@
 
     <group>
       <push-ros-namespace namespace="rear_left"/>
-      <include file="$(find-pkg-share nebula_ros)/launch/continental_launch_all_hw.xml" if="$(var launch_driver)">
+      <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/ars548.launch.xml">
         <arg name="odometry_topic" value="$(var odometry_topic)"/>
         <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
         <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+        <arg name="launch_hw" value="$(var launch_driver)"/>
 
         <arg name="sensor_ip" value="10.13.1.118"/>
         <arg name="frame_id" value="rear_left/radar_link"/>
@@ -174,10 +177,11 @@
 
     <group>
       <push-ros-namespace namespace="rear_right"/>
-      <include file="$(find-pkg-share nebula_ros)/launch/continental_launch_all_hw.xml" if="$(var launch_driver)">
+      <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/ars548.launch.xml">
         <arg name="odometry_topic" value="$(var odometry_topic)"/>
         <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
         <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+        <arg name="launch_hw" value="$(var launch_driver)"/>
 
         <arg name="sensor_ip" value="10.13.1.119"/>
         <arg name="frame_id" value="rear_right/radar_link"/>

--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -10,10 +10,6 @@
   <group>
     <push-ros-namespace namespace="radar"/>
 
-    <!--node pkg="tf2_ros" exec="static_transform_publisher" name="tf_broadcaster" output="screen" args="$(var wheel_base) 0 0 0 0 0 base_link autosar"/-->
-    <node pkg="topic_tools" exec="transform" name="steer_angle_transform" output="screen" args="/vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float32 'std_msgs.msg.Float32(data=m.steering_tire_angle)'  --import autoware_auto_vehicle_msgs std_msgs --wait-for-start"/>
-    <!-- ros2 run topic_tools transform /vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float64 'std_msgs.msg.Float64(data=m.steering_tire_angle)'  \-\-import autoware_auto_vehicle_msgs std_msgs -->
-
     <group>
       <push-ros-namespace namespace="front_center"/>
       <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/ars548.launch.xml">

--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -9,10 +9,7 @@
 
   <group>
     <push-ros-namespace namespace="radar"/>
-
-    <!--node pkg="tf2_ros" exec="static_transform_publisher" name="tf_broadcaster" output="screen" args="$(var wheel_base) 0 0 0 0 0 base_link autosar"/-->
-    <node pkg="topic_tools" exec="transform" name="steer_angle_transform" output="screen" args="/vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float32 'std_msgs.msg.Float32(data=m.steering_tire_angle)'  --import autoware_auto_vehicle_msgs std_msgs --wait-for-start"/>
-    <!-- ros2 run topic_tools transform /vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float64 'std_msgs.msg.Float64(data=m.steering_tire_angle)'  \-\-import autoware_auto_vehicle_msgs std_msgs -->
+    <node pkg="topic_tools" exec="transform" name="steer_angle_transform" output="screen" args="/vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float32 'std_msgs.msg.Float32(data=m.steering_tire_angle)'  --import autoware_vehicle_msgs std_msgs --wait-for-start"/>
 
     <group>
       <push-ros-namespace namespace="front_center"/>

--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -10,6 +10,10 @@
   <group>
     <push-ros-namespace namespace="radar"/>
 
+    <!--node pkg="tf2_ros" exec="static_transform_publisher" name="tf_broadcaster" output="screen" args="$(var wheel_base) 0 0 0 0 0 base_link autosar"/-->
+    <node pkg="topic_tools" exec="transform" name="steer_angle_transform" output="screen" args="/vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float32 'std_msgs.msg.Float32(data=m.steering_tire_angle)'  --import autoware_auto_vehicle_msgs std_msgs --wait-for-start"/>
+    <!-- ros2 run topic_tools transform /vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float64 'std_msgs.msg.Float64(data=m.steering_tire_angle)'  \-\-import autoware_auto_vehicle_msgs std_msgs -->
+
     <group>
       <push-ros-namespace namespace="front_center"/>
       <include file="$(find-pkg-share aip_x2_gen2_launch)/launch/ars548.launch.xml">


### PR DESCRIPTION
## Description
RADARのパラメータが正しく渡されていない問題があったため、`aip_x2_gen2_launch`に新たにRADAR用のlaunchを追加して、パラメータを渡すように修正。


Related:
- https://github.com/tier4/nebula/pull/209
- https://tier4.atlassian.net/browse/RT0-33906

## Tests
- Autowareを起動し、`sensor_ip`, `frame_id`などのパラメータが正しく渡されていることを確認
![image](https://github.com/user-attachments/assets/50e3bc6a-d8c5-43b5-bd5f-535123b2f818)

- detection_pointsのframe_idが書き換わっていることを確認
![image](https://github.com/user-attachments/assets/b790ee1e-fd8c-498b-a799-fcafd546fc47)

- logging simulatorで各RADARのtopicにdetection pointsがpublishされていることを確認
![image](https://github.com/user-attachments/assets/de8af379-66bd-44ba-9d52-c70b84a1ed29)

