### PR TITLE
feat(aip_x2_gen2_launch): enable self_crop_component

### DIFF
--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -206,7 +206,7 @@ def launch_setup(context, *args, **kwargs):
         remappings=[
             ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
             ("~/input/imu", "/sensing/imu/imu_data"),
-            ("~/input/pointcloud", "pointcloud_raw_ex"),
+            ("~/input/pointcloud", "self_cropped/pointcloud_ex"),
             ("~/output/pointcloud", "rectified/pointcloud_ex"),
         ],
         parameters=[load_composable_node_param("distortion_corrector_node_param_file")],
@@ -274,7 +274,7 @@ def launch_setup(context, *args, **kwargs):
         composable_node_descriptions=[
             glog_component,
             nebula_component,
-            # self_crop_component,
+            self_crop_component,
             # right_mirror_crop_component,
             # left_mirror_crop_component,
             undistort_component,


### PR DESCRIPTION
車体周辺のゴミ点群をFOV設定のみで除去しきれないためself_crop_componentを再度有効化
[関連slackスレ](https://star4.slack.com/archives/CRUE57C30/p1732096573432109)