### PR TITLE
fix(aip_x2_gen2_launch): fix front_upper cut_angle

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -171,7 +171,7 @@
         <arg name="host_ip" value="$(var host_ip)"/>
         <arg name="data_port" value="2323"/>
         <arg name="sync_angle" value="180"/>
-        <arg name="cut_angle" value="277.0" />
+        <arg name="cut_angle" value="275.0" />
         <arg name="cloud_min_angle" value="85"/>
         <arg name="cloud_max_angle" value="275"/>
         <arg name="return_mode" value="LastStrongest"/>


### PR DESCRIPTION
front_upperのcut_angleがFOV外になっていたのを修正(FOV縮小の時にcut_angleを修正し忘れた)
