### PR TITLE
fix(spinnaker_launch): upgrade mapping solution

### DIFF
--- a/common_sensor_launch/launch/spinnaker.launch.py
+++ b/common_sensor_launch/launch/spinnaker.launch.py
@@ -67,9 +67,7 @@ def launch_setup(context, *args, **kwargs):
                         "camera_info_url"
                     ),
                 },
-                {
-                    "use_image_transport": LaunchConfiguration("use_image_transport")
-                }
+                {"use_image_transport": LaunchConfiguration("use_image_transport")},
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),

--- a/common_sensor_launch/launch/spinnaker.launch.py
+++ b/common_sensor_launch/launch/spinnaker.launch.py
@@ -62,7 +62,7 @@ def launch_setup(context, *args, **kwargs):
                         LaunchConfiguration("camera_id"),
                         "/",
                         LaunchConfiguration("image_topic"),
-                        "/compressed"
+                        "/compressed",
                     ],
                 ),
                 (

--- a/common_sensor_launch/launch/spinnaker.launch.py
+++ b/common_sensor_launch/launch/spinnaker.launch.py
@@ -67,6 +67,9 @@ def launch_setup(context, *args, **kwargs):
                         "camera_info_url"
                     ),
                 },
+                {
+                    "use_image_tranport": LaunchConfiguration("use_image_tranport")
+                }
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),
@@ -106,6 +109,7 @@ def generate_launch_description():
     add_launch_arg("spinnaker_namespace", "/sensing/camera")
     add_launch_arg("spinnaker_param_path")
     add_launch_arg("camera_info_url")
+    add_launch_arg("use_image_tranport", "True")
     add_launch_arg("use_intra_process", "True")
     set_camera_info_url_key = SetLaunchConfiguration(
         "camera_info_url_key",

--- a/common_sensor_launch/launch/spinnaker.launch.py
+++ b/common_sensor_launch/launch/spinnaker.launch.py
@@ -55,6 +55,20 @@ def launch_setup(context, *args, **kwargs):
                     [
                         "camera",
                         LaunchConfiguration("camera_id"),
+                        "/image_raw/compressed",
+                    ],
+                    [
+                        "camera",
+                        LaunchConfiguration("camera_id"),
+                        "/",
+                        LaunchConfiguration("image_topic"),
+                        "/compressed"
+                    ],
+                ),
+                (
+                    [
+                        "camera",
+                        LaunchConfiguration("camera_id"),
                         "/camera_info",
                     ],
                     ["camera", LaunchConfiguration("camera_id"), "/camera_info"],

--- a/common_sensor_launch/launch/spinnaker.launch.py
+++ b/common_sensor_launch/launch/spinnaker.launch.py
@@ -67,13 +67,9 @@ def launch_setup(context, *args, **kwargs):
                         "camera_info_url"
                     ),
                 },
-<<<<<<< HEAD
                 {
                     "use_image_transport": LaunchConfiguration("use_image_transport")
                 }
-=======
-                {"use_image_tranport": LaunchConfiguration("use_image_tranport")},
->>>>>>> 38605787025d7a216b4e669674a0b8e21d58623b
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),

--- a/common_sensor_launch/launch/spinnaker.launch.py
+++ b/common_sensor_launch/launch/spinnaker.launch.py
@@ -39,7 +39,11 @@ def launch_setup(context, *args, **kwargs):
             namespace=LaunchConfiguration("spinnaker_namespace"),
             remappings=[
                 (
-                    "camera0/image_raw",
+                    [
+                        "camera",
+                        LaunchConfiguration("camera_id"),
+                        "/image_raw",
+                    ],
                     [
                         "camera",
                         LaunchConfiguration("camera_id"),
@@ -48,7 +52,11 @@ def launch_setup(context, *args, **kwargs):
                     ],
                 ),
                 (
-                    "camera0/camera_info",
+                    [
+                        "camera",
+                        LaunchConfiguration("camera_id"),
+                        "/camera_info",
+                    ],
                     ["camera", LaunchConfiguration("camera_id"), "/camera_info"],
                 ),
             ],

--- a/common_sensor_launch/launch/spinnaker.launch.py
+++ b/common_sensor_launch/launch/spinnaker.launch.py
@@ -68,7 +68,7 @@ def launch_setup(context, *args, **kwargs):
                     ),
                 },
                 {
-                    "use_image_tranport": LaunchConfiguration("use_image_tranport")
+                    "use_image_transport": LaunchConfiguration("use_image_transport")
                 }
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
@@ -109,7 +109,7 @@ def generate_launch_description():
     add_launch_arg("spinnaker_namespace", "/sensing/camera")
     add_launch_arg("spinnaker_param_path")
     add_launch_arg("camera_info_url")
-    add_launch_arg("use_image_tranport", "True")
+    add_launch_arg("use_image_transport", "True")
     add_launch_arg("use_intra_process", "True")
     set_camera_info_url_key = SetLaunchConfiguration(
         "camera_info_url_key",

--- a/common_sensor_launch/launch/spinnaker.launch.py
+++ b/common_sensor_launch/launch/spinnaker.launch.py
@@ -67,9 +67,7 @@ def launch_setup(context, *args, **kwargs):
                         "camera_info_url"
                     ),
                 },
-                {
-                    "use_image_tranport": LaunchConfiguration("use_image_tranport")
-                }
+                {"use_image_tranport": LaunchConfiguration("use_image_tranport")},
             ],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         ),


### PR DESCRIPTION
- Correctly configure the camera ID in remapping.
- Remap both raw images and compressed image.
- Taking consideration of https://github.com/tier4/spinnaker/pull/2, allow setting boolean option of whether to use image transport.

Tested on production Jetson Xavier system with multiple spinnaker images.