### PR TITLE
feat: temporary radar support for x2 gen2 v4.0.1

### DIFF
--- a/aip_x2_gen2_launch/config/simple_object_merger.param.yaml
+++ b/aip_x2_gen2_launch/config/simple_object_merger.param.yaml
@@ -3,4 +3,4 @@
     update_rate_hz: 20.0
     new_frame_id: "base_link"
     timeout_threshold: 1.0
-    input_topics: ["/sensing/radar/front_center/detected_objects", "/sensing/radar/front_left/detected_objects", "/sensing/radar/rear_left/detected_objects", "/sensing/radar/rear_center/detected_objects", "/sensing/radar/rear_right/detected_objects", "/sensing/radar/front_right/detected_objects"]
+    input_topics: ["/sensing/radar/front_center/detected_objects", "/sensing/radar/rear_center/detected_objects"]

--- a/common_sensor_launch/config/radar_tracks_msgs_converter.param.yaml
+++ b/common_sensor_launch/config/radar_tracks_msgs_converter.param.yaml
@@ -2,6 +2,6 @@
   ros__parameters:
     update_rate_hz: 20.0
     new_frame_id: "base_link"
-    use_twist_compensation: true
+    use_twist_compensation: false
     use_twist_yaw_compensation: false
     static_object_speed_threshold: 1.0


### PR DESCRIPTION
@TomohitoAndo 

ARS548を簡易的に使うための設定変更PRです．内容としては下記を含みます．

- 左右のradarの無効化
- motion compensationの無効化（ARS548になってセンサ側でこれができるようになったため）


<s>思っていたのと挙動が違うので一旦draftに戻します．</s>