### PR TITLE
chore(aip_x2_gen2_launch): fix blockage_angle

### DIFF
--- a/aip_x2_gen2_launch/config/blockage_diagnostics_param_file.yaml
+++ b/aip_x2_gen2_launch/config/blockage_diagnostics_param_file.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    blockage_ratio_threshold: 0.1
+    blockage_ratio_threshold: 0.2
     blockage_count_threshold: 50
     blockage_buffering_frames: 2
     blockage_buffering_interval: 1

--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -110,7 +110,7 @@
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="blockage_range" value="[90.0, 270.0]"/>
+        <arg name="blockage_range" value="[130.0, 230.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="118" />
         <arg name="is_channel_order_top2down" value="false"/>
@@ -142,7 +142,7 @@
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="blockage_range" value="[90.0, 270.0]"/>
+        <arg name="blockage_range" value="[140.0, 230.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="118" />
         <arg name="is_channel_order_top2down" value="false"/>
@@ -239,7 +239,7 @@
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="blockage_range" value="[90.0, 270.0]"/>
+        <arg name="blockage_range" value="[130.0, 230.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="118" />
         <arg name="is_channel_order_top2down" value="false"/>
@@ -271,7 +271,7 @@
         <arg name="launch_driver" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="blockage_range" value="[90.0, 270.0]"/>
+        <arg name="blockage_range" value="[145.0, 225.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="118" />
         <arg name="is_channel_order_top2down" value="false"/>


### PR DESCRIPTION
QT(lower)のblockage_diagが常時ERRORになっているため、判定角度を絞ります
絞ってもFOV削減設定である程度オフセットになるので、thresholdを0.1→0.2に変更しました。
[JIRA](https://tier4.atlassian.net/browse/RT0-34497)