### PR TITLE
fix: the name of velodyne lidar

### DIFF
--- a/aip_urdf_compiler/scripts/compile_urdf.py
+++ b/aip_urdf_compiler/scripts/compile_urdf.py
@@ -94,8 +94,7 @@ class Transformation:
                     "pandar" in self.type
                     or "livox" in self.type
                     or "camera" in self.type
-                    or "vls" in self.type.lower()
-                    or "vlp" in self.type.lower()
+                    or "velodyne" in self.type.lower()
                 ):
                     # For common sensor descriptions, LiDAR and camera macros will automatically
                     # be attached with a "base_link" name


### PR DESCRIPTION
This pull request fixes a bug at https://github.com/tier4/aip_launcher/pull/361.

## How was this PR tested?

- [x] `planning_simulator` with [sample_map](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- [x] `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- [x] `logging_simulator` with [awsim_gt_data(TIER IV INTERNAL)](https://drive.google.com/file/d/1BtH3Ry5lu-h85GHM-sYq_jNJLw-s0re6/view?usp=drive_link)
- [x] `e2e_simulator` with [AWSIM v1.3.1](https://github.com/tier4/AWSIM/releases/tag/v1.3.1)

