### PR TITLE
fix: change the parameters so that there would be no LiDAR flicker

### DIFF
--- a/aip_xx1_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/aip_xx1_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -21,4 +21,4 @@
     matching_strategy:
       type: advanced
       lidar_timestamp_offsets: [0.0, 0.02, 0.02, 0.02]
-      lidar_timestamp_noise_window: [0.02, 0.02, 0.02, 0.02]
+      lidar_timestamp_noise_window: [0.08, 0.08, 0.08, 0.08]


### PR DESCRIPTION
After merging https://github.com/tier4/aip_launcher/pull/337, the LiDAR started flickering when using `logging_simulator` with [the sample rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/).

## Result

Without this PR : 

[Screencast from 2025年01月22日 11時20分22秒.webm](https://github.com/user-attachments/assets/db930cdd-bb66-49b7-8a2d-122dbffe15ed)

With this PR : 

[Screencast from 2025年01月22日 11時28分04秒.webm](https://github.com/user-attachments/assets/abf86cf0-c5c3-443a-af35-6a764a0fce1b)


## Test Procedure

- build https://github.com/tier4/pilot-auto
- download https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/
- run
```bash
ros2 launch autoware_launch logging_simulator.launch.xml \
    map_path:=$HOME/autoware_map/sample-map-rosbag \
    vehicle_model:=lexus \
    sensor_model:=aip_xx1 
```

```bash
ros2 bag play $HOME/autoware_map/sample-rosbag/sample.db3 -r 1.0 -s sqlite3
```
