### PR TITLE
feat: add autoware_ prefix to topic_state_monitor package

### DIFF
--- a/aip_x1_launch/package.xml
+++ b/aip_x1_launch/package.xml
@@ -17,13 +17,13 @@
   <exec_depend>autoware_imu_corrector</exec_depend>
   <exec_depend>autoware_occupancy_grid_map_outlier_filter</exec_depend>
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
+  <exec_depend>autoware_topic_state_monitor</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>individual_params</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>ros2_socketcan</exec_depend>
   <exec_depend>tamagawa_imu_driver</exec_depend>
-  <exec_depend>topic_state_monitor</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/aip_x2_gen2_launch/launch/topic_state_monitor.launch.py
+++ b/aip_x2_gen2_launch/launch/topic_state_monitor.launch.py
@@ -21,7 +21,7 @@ def generate_launch_description():
     # GNSS topic monitor
     gnss_topic_monitor = ComposableNode(
         package="autoware_topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
+        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_gnss_pose",
         parameters=[
             {
@@ -41,7 +41,7 @@ def generate_launch_description():
     # IMU topic monitor
     imu_topic_monitor = ComposableNode(
         package="autoware_topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
+        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_imu_data",
         parameters=[
             {
@@ -61,7 +61,7 @@ def generate_launch_description():
     # Radar topic monitors
     radar_front_center_monitor = ComposableNode(
         package="autoware_topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
+        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_front_center",
         parameters=[
             {
@@ -80,7 +80,7 @@ def generate_launch_description():
 
     radar_front_left_monitor = ComposableNode(
         package="autoware_topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
+        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_front_left",
         parameters=[
             {
@@ -99,7 +99,7 @@ def generate_launch_description():
 
     radar_front_right_monitor = ComposableNode(
         package="autoware_topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
+        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_front_right",
         parameters=[
             {
@@ -118,7 +118,7 @@ def generate_launch_description():
 
     radar_rear_center_monitor = ComposableNode(
         package="autoware_topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
+        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_rear_center",
         parameters=[
             {
@@ -137,7 +137,7 @@ def generate_launch_description():
 
     radar_rear_left_monitor = ComposableNode(
         package="autoware_topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
+        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_rear_left",
         parameters=[
             {
@@ -156,7 +156,7 @@ def generate_launch_description():
 
     radar_rear_right_monitor = ComposableNode(
         package="autoware_topic_state_monitor",
-        plugin="topic_state_monitor::TopicStateMonitorNode",
+        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_rear_right",
         parameters=[
             {

--- a/aip_x2_gen2_launch/launch/topic_state_monitor.launch.py
+++ b/aip_x2_gen2_launch/launch/topic_state_monitor.launch.py
@@ -20,7 +20,7 @@ from launch_ros.descriptions import ComposableNode
 def generate_launch_description():
     # GNSS topic monitor
     gnss_topic_monitor = ComposableNode(
-        package="topic_state_monitor",
+        package="autoware_topic_state_monitor",
         plugin="topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_gnss_pose",
         parameters=[
@@ -40,7 +40,7 @@ def generate_launch_description():
 
     # IMU topic monitor
     imu_topic_monitor = ComposableNode(
-        package="topic_state_monitor",
+        package="autoware_topic_state_monitor",
         plugin="topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_imu_data",
         parameters=[
@@ -60,7 +60,7 @@ def generate_launch_description():
 
     # Radar topic monitors
     radar_front_center_monitor = ComposableNode(
-        package="topic_state_monitor",
+        package="autoware_topic_state_monitor",
         plugin="topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_front_center",
         parameters=[
@@ -79,7 +79,7 @@ def generate_launch_description():
     )
 
     radar_front_left_monitor = ComposableNode(
-        package="topic_state_monitor",
+        package="autoware_topic_state_monitor",
         plugin="topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_front_left",
         parameters=[
@@ -98,7 +98,7 @@ def generate_launch_description():
     )
 
     radar_front_right_monitor = ComposableNode(
-        package="topic_state_monitor",
+        package="autoware_topic_state_monitor",
         plugin="topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_front_right",
         parameters=[
@@ -117,7 +117,7 @@ def generate_launch_description():
     )
 
     radar_rear_center_monitor = ComposableNode(
-        package="topic_state_monitor",
+        package="autoware_topic_state_monitor",
         plugin="topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_rear_center",
         parameters=[
@@ -136,7 +136,7 @@ def generate_launch_description():
     )
 
     radar_rear_left_monitor = ComposableNode(
-        package="topic_state_monitor",
+        package="autoware_topic_state_monitor",
         plugin="topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_rear_left",
         parameters=[
@@ -155,7 +155,7 @@ def generate_launch_description():
     )
 
     radar_rear_right_monitor = ComposableNode(
-        package="topic_state_monitor",
+        package="autoware_topic_state_monitor",
         plugin="topic_state_monitor::TopicStateMonitorNode",
         name="topic_state_monitor_radar_rear_right",
         parameters=[

--- a/aip_x2_gen2_launch/package.xml
+++ b/aip_x2_gen2_launch/package.xml
@@ -17,6 +17,7 @@
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>autoware_radar_tracks_msgs_converter</exec_depend>
   <exec_depend>autoware_simple_object_merger</exec_depend>
+  <exec_depend>autoware_topic_state_monitor</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>
   <exec_depend>common_sensor_launch</exec_depend>
   <exec_depend>septentrio_gnss_driver</exec_depend>


### PR DESCRIPTION
## Description
This PR adds autoware_ prefix to topic_state_monitor package.
For the details, please refer to https://github.com/autowarefoundation/autoware.universe/pull/9961.

## How was this PR tested?
ros2 launch aip_x2_gen2_launch topic_state_monitor.launch.py

## Notes for reviewers

This must be merged with https://github.com/autowarefoundation/autoware.universe/pull/9961