### PR TITLE
chore(aip_x2_gen2_launch): remove distance_range

### DIFF
--- a/aip_x2_gen2_launch/launch/hesai_OT128.launch.xml
+++ b/aip_x2_gen2_launch/launch/hesai_OT128.launch.xml
@@ -21,7 +21,6 @@
   <arg name="setup_sensor" default="true"/>
   <arg name="min_range" default="0.3"/>
   <arg name="max_range" default="230.0"/>
-  <arg name="distance_range" default="[0.3, 230.0]"/>
   <arg name="blockage_range" default="[90.0, 270.0]"/>
   <arg name="vertical_bins" default ="128" />
   <arg name="horizontal_ring_id" default="12" />
@@ -60,7 +59,6 @@
 
     <arg name="min_range" value="$(var min_range)"/>
     <arg name="max_range" value="$(var max_range)"/>
-    <arg name="distance_range" value="$(var distance_range)"/>
     <arg name="blockage_range" value="$(var blockage_range)"/>
     <arg name="vertical_bins" value ="$(var vertical_bins)"/>
     <arg name="horizontal_ring_id" value="$(var horizontal_ring_id)" />

--- a/aip_x2_gen2_launch/launch/hesai_QT128.launch.xml
+++ b/aip_x2_gen2_launch/launch/hesai_QT128.launch.xml
@@ -22,7 +22,6 @@
   <arg name="container_name" default="hesai_node_container"/>
   <arg name="min_range" default="0.05"/>
   <arg name="max_range" default="50.0"/>
-  <arg name="distance_range" default="[0.05, 50.0]"/>
   <arg name="blockage_range" default="[90.0, 270.0]"/>
   <arg name="vertical_bins" default ="128" />
   <arg name="horizontal_ring_id" default="12" />
@@ -59,7 +58,6 @@
     <arg name="container_name" value="$(var container_name)"/>
     <arg name="min_range" value="$(var min_range)"/>
     <arg name="max_range" value="$(var max_range)"/>
-    <arg name="distance_range" value="$(var distance_range)"/>
     <arg name="blockage_range" value="$(var blockage_range)"/>
     <arg name="vertical_bins" value ="$(var vertical_bins)"/>
     <arg name="horizontal_ring_id" value="$(var horizontal_ring_id)" />

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -191,7 +191,6 @@ def launch_setup(context, *args, **kwargs):
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
-    distance_range = str2vector(context.perform_substitution(LaunchConfiguration("distance_range")))
     blockage_diag_component = ComposableNode(
         package="autoware_pointcloud_preprocessor",
         plugin="autoware::pointcloud_preprocessor::BlockageDiagComponent",
@@ -206,7 +205,7 @@ def launch_setup(context, *args, **kwargs):
                 "horizontal_ring_id": LaunchConfiguration("horizontal_ring_id"),
                 "vertical_bins": LaunchConfiguration("vertical_bins"),
                 "is_channel_order_top2down": LaunchConfiguration("is_channel_order_top2down"),
-                "max_distance_range": distance_range[1],
+                "max_distance_range": LaunchConfiguration("max_range"),
                 "horizontal_resolution": LaunchConfiguration("horizontal_resolution"),
             }
         ]


### PR DESCRIPTION
https://github.com/tier4/aip_launcher/pull/376 をcherry-pick
distance_rangeがmin_range, maxa_rangeと二重定義だったので除外