### PR TITLE
chore: sort dummy diags to match aggregator config

### DIFF
--- a/aip_x1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -12,6 +12,19 @@
 /**:
   ros__parameters:
     required_diags:
+      # sensing
+      sensing_topic_status: default
+
+      # velodyne
+      velodyne_connection: default
+      velodyne_temperature: default
+      velodyne_rpm: default
+
+      # pandar
+      pandar_connection: default
+      pandar_temperature: default
+      pandar_ptp: default
+
       # gnss
       gnss_connection: default
       gnss_data: default
@@ -20,18 +33,6 @@
       gnss_spoofing: default
       gnss_jamming: default
       fix topic status: default
-
-      # pandar
-      pandar_connection: default
-      pandar_temperature: default
-      pandar_ptp: default
-
-      # velodyne
-      velodyne_connection: default
-      velodyne_temperature: default
-      velodyne_rpm: default
-
-      sensing_topic_status: default
 
       # imu
       gyro_bias_estimator: default


### PR DESCRIPTION
[aggregatorのコンフィグ](https://github.com/tier4/aip_launcher/blob/tier4/universe/aip_x1_launch/config/diagnostic_aggregator/sensor_kit.param.yaml)や[launchの順番](https://github.com/tier4/aip_launcher/blob/c5dbc573042f8b5e3fffd09ef948c8fb28149904/aip_x1_launch/launch/sensing.launch.xml#L10-L25)に合わせて、dummy_diagのコンフィグをソート