### PR TITLE
chore(aip_x1): remove "use_radius_search" param in lidar.launch.xml

### DIFF
--- a/aip_x1_launch/launch/lidar.launch.xml
+++ b/aip_x1_launch/launch/lidar.launch.xml
@@ -3,7 +3,6 @@
   <arg name="launch_driver" default="true" />
   <arg name="host_ip" default="127.0.0.1"/>
   <arg name="use_concat_filter" default="true" />
-  <arg name="use_radius_search" default="false" />
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" />
   <arg name="vehicle_mirror_param_file" />
   <arg name="pointcloud_container_name" default="pointcloud_container"/>


### PR DESCRIPTION
使用されていないパラメータ `use_radius_search` を削除