### PR TITLE
chore(common): remove "launch_hw_monitor" param in hesai_*.launch.xml

### DIFF
--- a/common_sensor_launch/launch/hesai_OT128.launch.xml
+++ b/common_sensor_launch/launch/hesai_OT128.launch.xml
@@ -2,9 +2,6 @@
 
   <!-- Params -->
   <arg name="launch_driver" default="true"/>
-  <!-- There is an issue where hw_monitor crashes due to data race,
-  so the monitor will now only be launched when explicitly specified with a launch command. -->
-  <arg name="launch_hw_monitor" default="false"/>
 
   <arg name="model" default="Pandar128E4X"/>
   <arg name="sensor_frame" default="pandar"/>

--- a/common_sensor_launch/launch/hesai_XT32.launch.xml
+++ b/common_sensor_launch/launch/hesai_XT32.launch.xml
@@ -2,9 +2,6 @@
 
   <!-- Params -->
   <arg name="launch_driver" default="true"/>
-  <!-- There is an issue where hw_monitor crashes due to data race,
-  so the monitor will now only be launched when explicitly specified with a launch command. -->
-  <arg name="launch_hw_monitor" default="false"/>
 
   <arg name="model" default="PandarXT32"/>
   <arg name="sensor_frame" default="pandar"/>


### PR DESCRIPTION
With https://github.com/tier4/aip_launcher/pull/360, `launch_hw_monitor` param is no longer available.