### PR TITLE
fix(aip_x2_gen2_launch): add `autoware_` prefix to glog component

### DIFF
--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -76,7 +76,7 @@ def launch_setup(context, *args, **kwargs):
 
     glog_component = ComposableNode(
         package="autoware_glog_component",
-        plugin="GlogComponent",
+        plugin="autoware::glog_component::GlogComponent",
         name="glog_component",
     )
 


### PR DESCRIPTION
## Description
I added missing `autoware::glog_component::` to avoid launch error.

Related PR:
- https://github.com/tier4/aip_launcher/pull/370