### PR TITLE
chore(aip_x2_gen2_launch): return mode LastStrongest

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -38,7 +38,7 @@
         <arg name="cut_angle" value="180.0" />
         <arg name="cloud_min_angle" value="88"/>
         <arg name="cloud_max_angle" value="274"/>
-        <arg name="return_mode" value="Dual"/>
+        <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.3"/>
         <arg name="max_range" value="230.0"/>
         <arg name="ptp_profile" value="automotive"/>
@@ -80,7 +80,7 @@
         <arg name="cut_angle" value="359.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="359"/>
-        <arg name="return_mode" value="Dual"/>
+        <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.3"/>
         <arg name="max_range" value="230.0"/>
         <arg name="ptp_profile" value="automotive"/>
@@ -122,7 +122,7 @@
         <arg name="cut_angle" value="180.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
-        <arg name="return_mode" value="Dual"/>
+        <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.05"/>
         <arg name="max_range" value="50.0"/>
         <arg name="ptp_profile" value="automotive"/>
@@ -164,7 +164,7 @@
         <arg name="cut_angle" value="270.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
-        <arg name="return_mode" value="Dual"/>
+        <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.05"/>
         <arg name="max_range" value="50.0"/>
         <arg name="ptp_profile" value="automotive"/>
@@ -207,7 +207,7 @@
         <arg name="cut_angle" value="275.0" />
         <arg name="cloud_min_angle" value="85"/>
         <arg name="cloud_max_angle" value="275"/>
-        <arg name="return_mode" value="Dual"/>
+        <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.3"/>
         <arg name="max_range" value="230.0"/>
         <arg name="ptp_profile" value="automotive"/>
@@ -249,7 +249,7 @@
         <arg name="cut_angle" value="270.0" />
         <arg name="cloud_min_angle" value="0"/>
         <arg name="cloud_max_angle" value="270"/>
-        <arg name="return_mode" value="Dual"/>
+        <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.3"/>
         <arg name="max_range" value="230.0"/>
         <arg name="ptp_profile" value="automotive"/>
@@ -291,7 +291,7 @@
         <arg name="cut_angle" value="270.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
-        <arg name="return_mode" value="Dual"/>
+        <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.05"/>
         <arg name="max_range" value="50.0"/>
         <arg name="ptp_profile" value="automotive"/>
@@ -333,7 +333,7 @@
         <arg name="cut_angle" value="270.0" />
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
-        <arg name="return_mode" value="Dual"/>
+        <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.05"/>
         <arg name="max_range" value="50.0"/>
         <arg name="ptp_profile" value="automotive"/>


### PR DESCRIPTION
[以前のPR](https://github.com/tier4/aip_launcher/pull/387#discussion_r1942612223)で`LastStrongest`のままdual_return_filter使用することにしていたが、[別のPR](https://github.com/tier4/aip_launcher/pull/388)で誤って`Dual`に設定されていたため戻す。

ベンチで機能することを確認済み。