### PR TITLE
fix(aip_x2_gen2_launch):  QT128 OT128 sensor range

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -39,8 +39,8 @@
         <arg name="cloud_min_angle" value="88"/>
         <arg name="cloud_max_angle" value="274"/>
         <arg name="return_mode" value="Dual"/>
-        <arg name="min_range" value="0.05"/>
-        <arg name="max_range" value="50.0"/>
+        <arg name="min_range" value="0.3"/>
+        <arg name="max_range" value="230.0"/>
         <arg name="ptp_profile" value="automotive"/>
         <arg name="ptp_transport_type" value="L2"/>
         <arg name="ptp_switch_type" value="NON_TSN"/>
@@ -81,8 +81,8 @@
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="359"/>
         <arg name="return_mode" value="Dual"/>
-        <arg name="min_range" value="0.05"/>
-        <arg name="max_range" value="50.0"/>
+        <arg name="min_range" value="0.3"/>
+        <arg name="max_range" value="230.0"/>
         <arg name="ptp_profile" value="automotive"/>
         <arg name="ptp_transport_type" value="L2"/>
         <arg name="ptp_switch_type" value="NON_TSN"/>
@@ -123,8 +123,8 @@
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
         <arg name="return_mode" value="Dual"/>
-        <arg name="min_range" value="0.3"/>
-        <arg name="max_range" value="230.0"/>
+        <arg name="min_range" value="0.05"/>
+        <arg name="max_range" value="50.0"/>
         <arg name="ptp_profile" value="automotive"/>
         <arg name="ptp_transport_type" value="L2"/>
         <arg name="ptp_switch_type" value="NON_TSN"/>
@@ -165,8 +165,8 @@
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
         <arg name="return_mode" value="Dual"/>
-        <arg name="min_range" value="0.3"/>
-        <arg name="max_range" value="230.0"/>
+        <arg name="min_range" value="0.05"/>
+        <arg name="max_range" value="50.0"/>
         <arg name="ptp_profile" value="automotive"/>
         <arg name="ptp_transport_type" value="L2"/>
         <arg name="ptp_switch_type" value="NON_TSN"/>
@@ -208,8 +208,8 @@
         <arg name="cloud_min_angle" value="85"/>
         <arg name="cloud_max_angle" value="275"/>
         <arg name="return_mode" value="Dual"/>
-        <arg name="min_range" value="0.05"/>
-        <arg name="max_range" value="50.0"/>
+        <arg name="min_range" value="0.3"/>
+        <arg name="max_range" value="230.0"/>
         <arg name="ptp_profile" value="automotive"/>
         <arg name="ptp_transport_type" value="L2"/>
         <arg name="ptp_switch_type" value="NON_TSN"/>
@@ -250,8 +250,8 @@
         <arg name="cloud_min_angle" value="0"/>
         <arg name="cloud_max_angle" value="270"/>
         <arg name="return_mode" value="Dual"/>
-        <arg name="min_range" value="0.05"/>
-        <arg name="max_range" value="50.0"/>
+        <arg name="min_range" value="0.3"/>
+        <arg name="max_range" value="230.0"/>
         <arg name="ptp_profile" value="automotive"/>
         <arg name="ptp_transport_type" value="L2"/>
         <arg name="ptp_switch_type" value="NON_TSN"/>
@@ -292,8 +292,8 @@
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
         <arg name="return_mode" value="Dual"/>
-        <arg name="min_range" value="0.3"/>
-        <arg name="max_range" value="230.0"/>
+        <arg name="min_range" value="0.05"/>
+        <arg name="max_range" value="50.0"/>
         <arg name="ptp_profile" value="automotive"/>
         <arg name="ptp_transport_type" value="L2"/>
         <arg name="ptp_switch_type" value="NON_TSN"/>
@@ -334,8 +334,8 @@
         <arg name="cloud_min_angle" value="90"/>
         <arg name="cloud_max_angle" value="270"/>
         <arg name="return_mode" value="Dual"/>
-        <arg name="min_range" value="0.3"/>
-        <arg name="max_range" value="230.0"/>
+        <arg name="min_range" value="0.05"/>
+        <arg name="max_range" value="50.0"/>
         <arg name="ptp_profile" value="automotive"/>
         <arg name="ptp_transport_type" value="L2"/>
         <arg name="ptp_switch_type" value="NON_TSN"/>


### PR DESCRIPTION
OT128(upper)のsensor range [0.3,230]
QT128(lower)のsensor range [0.05, 50]
が逆に設定されていたので修正。lsimで動作確認
![image](https://github.com/user-attachments/assets/93c32424-666c-4ba6-9919-a1aca9bc5157)
