### PR TITLE
fix(gnss): update gnss parameter

### DIFF
--- a/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
+++ b/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
@@ -1,4 +1,19 @@
 /**:
+  # cspell: ignore ntrip
+  # cspell: ignore gpsfix
+  # cspell: ignore gpgga
+  # cspell: ignore gprmc
+  # cspell: ignore gpst
+  # cspell: ignore measepoch
+  # cspell: ignore pvtcartesian
+  # cspell: ignore basevectorcart
+  # cspell: ignore basevectorgeod
+  # cspell: ignore poscovcartesian
+  # cspell: ignore velcovgeodetic
+  # cspell: ignore atteuler
+  # cspell: ignore attcoveuler
+  # cspell: ignore gpgsa
+  # cspell: ignore gpgsv
   ros__parameters:
     device: tcp://192.168.20.102:28784
 

--- a/aip_xx1_gen2_launch/config/asterx_sb3_rover.param.yaml
+++ b/aip_xx1_gen2_launch/config/asterx_sb3_rover.param.yaml
@@ -1,4 +1,19 @@
 /**:
+  # cspell: ignore ntrip
+  # cspell: ignore gpsfix
+  # cspell: ignore gpgga
+  # cspell: ignore gprmc
+  # cspell: ignore gpst
+  # cspell: ignore measepoch
+  # cspell: ignore pvtcartesian
+  # cspell: ignore basevectorcart
+  # cspell: ignore basevectorgeod
+  # cspell: ignore poscovcartesian
+  # cspell: ignore velcovgeodetic
+  # cspell: ignore atteuler
+  # cspell: ignore attcoveuler
+  # cspell: ignore gpgsa
+  # cspell: ignore gpgsv
   ros__parameters:
     device: tcp://192.168.20.102:28784
 

--- a/aip_xx1_gen2_launch/config/asterx_sb3_rover.param.yaml
+++ b/aip_xx1_gen2_launch/config/asterx_sb3_rover.param.yaml
@@ -1,19 +1,4 @@
 /**:
-  # cspell: ignore ntrip
-  # cspell: ignore gpsfix
-  # cspell: ignore gpgga
-  # cspell: ignore gprmc
-  # cspell: ignore gpst
-  # cspell: ignore measepoch
-  # cspell: ignore pvtcartesian
-  # cspell: ignore basevectorcart
-  # cspell: ignore basevectorgeod
-  # cspell: ignore poscovcartesian
-  # cspell: ignore velcovgeodetic
-  # cspell: ignore atteuler
-  # cspell: ignore attcoveuler
-  # cspell: ignore gpgsa
-  # cspell: ignore gpgsv
   ros__parameters:
     device: tcp://192.168.20.102:28784
 
@@ -22,7 +7,7 @@
     get_spatial_config_from_tf: false
     use_ros_axis_orientation: false
     receiver_type: gnss
-    multi_antenna: false
+    multi_antenna: true
 
     datum: Default
 
@@ -30,9 +15,9 @@
       heading: -90.0
       pitch: 0.0
 
-    ant_type: Unknown
+    ant_type: "SEPPOLANT_MC.V2 NONE"
     ant_serial_nr: Unknown
-    ant_aux1_type: Unknown
+    ant_aux1_type: "SEPPOLANT_MC.V2 NONE"
     ant_aux1_serial_nr: Unknown
 
     polling_period:

--- a/aip_xx1_gen2_launch/launch/gnss.launch.xml
+++ b/aip_xx1_gen2_launch/launch/gnss.launch.xml
@@ -8,7 +8,7 @@
     <!-- Septentrio GNSS Driver -->
     <!-- cspell: ignore atteuler -->
     <node pkg="septentrio_gnss_driver" name="septentrio" exec="septentrio_gnss_driver_node" if="$(var launch_driver)">
-      <param from="$(find-pkg-share aip_xx1_gen2_launch)/config/mosaic_x5_rover.param.yaml"/>
+      <param from="$(find-pkg-share aip_xx1_gen2_launch)/config/asterx_sb3_rover.param.yaml"/>
       <remap from="navsatfix" to="~/nav_sat_fix"/>
       <remap from="poscovgeodetic" to="~/poscovgeodetic"/>
       <remap from="pvtgeodetic" to="~/pvtgeodetic"/>


### PR DESCRIPTION
Gen2.0で使用しているSeptentrio AsteRx SB3の設定ファイルのPRです。

https://star4.slack.com/archives/CEV8XMJBV/p1741572497427239?thread_ts=1741568657.233309&cid=CEV8XMJBV

---
合わせて  `asterx_sb3_rover.param.yaml` に `cspell ignore` を追加しました。
septentrio固有のキーワードがtypo判定されなくなります。