### PR TITLE
fix: update lidar_timestamp_offset

### DIFF
--- a/aip_x1_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/aip_x1_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -18,5 +18,5 @@
     output_frame: base_link
     matching_strategy:
       type: advanced
-      lidar_timestamp_offsets: [0.0, 0.03]
+      lidar_timestamp_offsets: [0.0, 0.0]
       lidar_timestamp_noise_window: [0.01, 0.01]


### PR DESCRIPTION
以下のようなシーンでoffsetを変更する必要があると理解しているが現状のX1ではこれらのシーンを満たしていないのでoffsetはなくていいと考える。
- LiDARの種類が異なる
- ScanPhase (スキャンの切れ目がどこにあるか)を変えている

AWSIMにてこの変更で動作することは確認できている。 (元のパラメータではconcatできなかった。)

変更前
![image](https://github.com/user-attachments/assets/dd21d2ac-75e8-43ce-aafe-88f328511a80)

変更後
![image](https://github.com/user-attachments/assets/6d1a2e85-1066-4498-ae27-a41d96746689)
