### PR TITLE
chore(aip_x2_gen2_launch): tune blockage_ratio_threshold 0.8

### DIFF
--- a/aip_x2_gen2_launch/config/blockage_diagnostics_param_file.yaml
+++ b/aip_x2_gen2_launch/config/blockage_diagnostics_param_file.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    blockage_ratio_threshold: 0.2
+    blockage_ratio_threshold: 0.8
     blockage_count_threshold: 50
     blockage_buffering_frames: 2
     blockage_buffering_interval: 1


### PR DESCRIPTION
雨路面やスモークガラスあり車両での点群欠けによるblockage ERRORを回避するためにthresholdを0.8に引き上げる。
これによりground側8割以下の遮蔽ではblockage検知できなくなる。[JIRA](https://tier4.atlassian.net/browse/RT0-35776?focusedCommentId=212957)