### PR TITLE
feat(dummy_diag_publisher): add config for xx1, gen2 vehicle

### DIFF
--- a/aip_xx1_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_xx1_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -12,19 +12,48 @@
 /**:
   ros__parameters:
     required_diags:
-      # gnss
-      gnss_connection: default
-      gnss_data: default
-      gnss_antenna: default
-      gnss_tx_usage: default
-      gnss_spoofing: default
-      gnss_jamming: default
-      fix topic status: default
-
-      # velodyne
-      velodyne_connection: default
-      velodyne_temperature: default
-      velodyne_rpm: default
-
       # imu
-      gyro_bias_estimator: default
+      "topic_state_monitor_imu: sensing_topic_status": default
+
+      #gyro_odometer
+      "gyro_odometer: gyro_odometer_status": default
+
+      #camera
+      "topic_state_monitor_camera0: sensing_topic_status": default
+      "topic_state_monitor_camera1: sensing_topic_status": default
+      "topic_state_monitor_camera2: sensing_topic_status": default
+      "topic_state_monitor_camera3: sensing_topic_status": default
+      "topic_state_monitor_camera4: sensing_topic_status": default
+      "topic_state_monitor_camera5: sensing_topic_status": default
+      "topic_state_monitor_camera6: sensing_topic_status": default
+      "topic_state_monitor_camera7: sensing_topic_status": default
+      "topic_state_monitor_camera8: sensing_topic_status": default
+      "topic_state_monitor_camera9: sensing_topic_status": default
+      "topic_state_monitor_camera10: sensing_topic_status": default
+
+      #lidar
+      "concatenate_data: concat_status": default
+
+      "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_status": default
+      "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_ptp": default
+      "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_temperature": default
+
+      "/sensing/lidar/side_right/hesai_ros_wrapper_node: hesai_status": default
+      "/sensing/lidar/side_right/hesai_ros_wrapper_node: hesai_ptp": default
+      "/sensing/lidar/side_right/hesai_ros_wrapper_node: hesai_temperature": default
+
+      "/sensing/lidar/front_left/hesai_ros_wrapper_node: hesai_status": default
+      "/sensing/lidar/front_left/hesai_ros_wrapper_node: hesai_ptp": default
+      "/sensing/lidar/front_left/hesai_ros_wrapper_node: hesai_temperature": default
+
+      "/sensing/lidar/front_right/hesai_ros_wrapper_node: hesai_status": default
+      "/sensing/lidar/front_right/hesai_ros_wrapper_node: hesai_ptp": default
+      "/sensing/lidar/front_right/hesai_ros_wrapper_node: hesai_temperature": default
+
+      "/sensing/lidar/top/hesai_ros_wrapper_node: hesai_status": default
+      "/sensing/lidar/top/hesai_ros_wrapper_node: hesai_ptp": default
+      "/sensing/lidar/top/hesai_ros_wrapper_node: hesai_temperature": default
+
+      # "/sensing/lidar/rear/hesai_ros_wrapper_node: hesai_status": default,
+      # "/sensing/lidar/rear/hesai_ros_wrapper_node: hesai_ptp": default,
+      # "/sensing/lidar/rear/hesai_ros_wrapper_node: hesai_temperature": default

--- a/aip_xx1_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_xx1_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -15,19 +15,20 @@
       # imu
       "topic_state_monitor_imu: sensing_topic_status": default
 
-      #gyro_odometer
-      "gyro_odometer: gyro_odometer_status": default
+      #gyro_bias_validator
+      "gyro_bias_validator: gyro_bias_validator": default
 
       #camera
+      #camera 1, 7 and 8 on the addon ECU are not currently not in use
       "topic_state_monitor_camera0: sensing_topic_status": default
-      "topic_state_monitor_camera1: sensing_topic_status": default
+      # "topic_state_monitor_camera1: sensing_topic_status": default
       "topic_state_monitor_camera2: sensing_topic_status": default
       "topic_state_monitor_camera3: sensing_topic_status": default
       "topic_state_monitor_camera4: sensing_topic_status": default
       "topic_state_monitor_camera5: sensing_topic_status": default
       "topic_state_monitor_camera6: sensing_topic_status": default
-      "topic_state_monitor_camera7: sensing_topic_status": default
-      "topic_state_monitor_camera8: sensing_topic_status": default
+      # "topic_state_monitor_camera7: sensing_topic_status": default
+      # "topic_state_monitor_camera8: sensing_topic_status": default
       "topic_state_monitor_camera9: sensing_topic_status": default
       "topic_state_monitor_camera10: sensing_topic_status": default
 

--- a/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -12,44 +12,34 @@
 /**:
   ros__parameters:
     required_diags:
-      "topic_state_monitor_imu: sensing_topic_status": default,
+      # performance monitoring  ----> To be confirmed in v0.47.0
+      # "blockage: blockage_validation": default
 
-      "gyro_odometer: gyro_odometer_status": default,
+      # velodyne
+      "velodyne_monitor: velodyne_connection": default
+      "velodyne_monitor: velodyne_temperature": default
+      "velodyne_monitor: velodyne_rpm": default
 
-      "topic_state_monitor_camera0: sensing_topic_status": default,
-      "topic_state_monitor_camera1: sensing_topic_status": default,
-      "topic_state_monitor_camera2: sensing_topic_status": default,
-      "topic_state_monitor_camera3: sensing_topic_status": default,
-      "topic_state_monitor_camera4: sensing_topic_status": default,
-      "topic_state_monitor_camera5: sensing_topic_status": default,
-      "topic_state_monitor_camera6: sensing_topic_status": default,
-      "topic_state_monitor_camera7: sensing_topic_status": default,
-      "topic_state_monitor_camera8: sensing_topic_status": default,
-      "topic_state_monitor_camera9: sensing_topic_status": default,
-      "topic_state_monitor_camera10: sensing_topic_status": default,
+      # gnss
+      # "connection: gnss_connection": default
+      # "data: gnss_data": default
+      # "antenna: gnss_antenna": default
+      # "tx_usage: gnss_tx_usage": default
+      # "spoofing: gnss_spoofing": default
+      # "jamming: gnss_jamming": default
+      # "fix_topic_status: fix topic status": default
+      "ublox: fix topic status": default
+      "ublox: fix": default
 
-      "concatenate_data: concat_status": default,
+      # camera
+      "topic_state_monitor_camera0: sensing_topic_status": default
+      "topic_state_monitor_camera1: sensing_topic_status": default
+      "topic_state_monitor_camera2: sensing_topic_status": default
+      "topic_state_monitor_camera3: sensing_topic_status": default
+      "topic_state_monitor_camera4: sensing_topic_status": default
+      "topic_state_monitor_camera5: sensing_topic_status": default
+      "topic_state_monitor_camera6: sensing_topic_status": default
 
-      "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_status": default,
-      "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_ptp": default,
-      "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_temperature": default,
-      
-      "/sensing/lidar/side_right/hesai_ros_wrapper_node: hesai_status": default,
-      "/sensing/lidar/side_right/hesai_ros_wrapper_node: hesai_ptp": default,
-      "/sensing/lidar/side_right/hesai_ros_wrapper_node: hesai_temperature": default,
-      
-      "/sensing/lidar/front_left/hesai_ros_wrapper_node: hesai_status": default,
-      "/sensing/lidar/front_left/hesai_ros_wrapper_node: hesai_ptp": default,
-      "/sensing/lidar/front_left/hesai_ros_wrapper_node: hesai_temperature": default,
-      
-      "/sensing/lidar/front_right/hesai_ros_wrapper_node: hesai_status": default,
-      "/sensing/lidar/front_right/hesai_ros_wrapper_node: hesai_ptp": default,
-      "/sensing/lidar/front_right/hesai_ros_wrapper_node: hesai_temperature": default,
-      
-      "/sensing/lidar/top/hesai_ros_wrapper_node: hesai_status": default,
-      "/sensing/lidar/top/hesai_ros_wrapper_node: hesai_ptp": default,
-      "/sensing/lidar/top/hesai_ros_wrapper_node: hesai_temperature": default
-      
-      # "/sensing/lidar/rear/hesai_ros_wrapper_node: hesai_status": default,
-      # "/sensing/lidar/rear/hesai_ros_wrapper_node: hesai_ptp": default,
-      # "/sensing/lidar/rear/hesai_ros_wrapper_node: hesai_temperature": default
+      # imu
+      "topic_state_monitor_imu: sensing_topic_status": default
+      "gyro_bias_validator: gyro_bias_validator": default

--- a/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -12,34 +12,44 @@
 /**:
   ros__parameters:
     required_diags:
-      # performance monitoring  ----> To be confirmed in v0.47.0
-      # "blockage: blockage_validation": default
+      "topic_state_monitor_imu: sensing_topic_status": default,
 
-      # velodyne
-      "velodyne_monitor: velodyne_connection": default
-      "velodyne_monitor: velodyne_temperature": default
-      "velodyne_monitor: velodyne_rpm": default
+      "gyro_odometer: gyro_odometer_status": default,
 
-      # gnss
-      # "connection: gnss_connection": default
-      # "data: gnss_data": default
-      # "antenna: gnss_antenna": default
-      # "tx_usage: gnss_tx_usage": default
-      # "spoofing: gnss_spoofing": default
-      # "jamming: gnss_jamming": default
-      # "fix_topic_status: fix topic status": default
-      "ublox: fix topic status": default
-      "ublox: fix": default
+      "topic_state_monitor_camera0: sensing_topic_status": default,
+      "topic_state_monitor_camera1: sensing_topic_status": default,
+      "topic_state_monitor_camera2: sensing_topic_status": default,
+      "topic_state_monitor_camera3: sensing_topic_status": default,
+      "topic_state_monitor_camera4: sensing_topic_status": default,
+      "topic_state_monitor_camera5: sensing_topic_status": default,
+      "topic_state_monitor_camera6: sensing_topic_status": default,
+      "topic_state_monitor_camera7: sensing_topic_status": default,
+      "topic_state_monitor_camera8: sensing_topic_status": default,
+      "topic_state_monitor_camera9: sensing_topic_status": default,
+      "topic_state_monitor_camera10: sensing_topic_status": default,
 
-      # camera
-      "topic_state_monitor_camera0: sensing_topic_status": default
-      "topic_state_monitor_camera1: sensing_topic_status": default
-      "topic_state_monitor_camera2: sensing_topic_status": default
-      "topic_state_monitor_camera3: sensing_topic_status": default
-      "topic_state_monitor_camera4: sensing_topic_status": default
-      "topic_state_monitor_camera5: sensing_topic_status": default
-      "topic_state_monitor_camera6: sensing_topic_status": default
+      "concatenate_data: concat_status": default,
 
-      # imu
-      "topic_state_monitor_imu: sensing_topic_status": default
-      "gyro_bias_validator: gyro_bias_validator": default
+      "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_status": default,
+      "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_ptp": default,
+      "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_temperature": default,
+      
+      "/sensing/lidar/side_right/hesai_ros_wrapper_node: hesai_status": default,
+      "/sensing/lidar/side_right/hesai_ros_wrapper_node: hesai_ptp": default,
+      "/sensing/lidar/side_right/hesai_ros_wrapper_node: hesai_temperature": default,
+      
+      "/sensing/lidar/front_left/hesai_ros_wrapper_node: hesai_status": default,
+      "/sensing/lidar/front_left/hesai_ros_wrapper_node: hesai_ptp": default,
+      "/sensing/lidar/front_left/hesai_ros_wrapper_node: hesai_temperature": default,
+      
+      "/sensing/lidar/front_right/hesai_ros_wrapper_node: hesai_status": default,
+      "/sensing/lidar/front_right/hesai_ros_wrapper_node: hesai_ptp": default,
+      "/sensing/lidar/front_right/hesai_ros_wrapper_node: hesai_temperature": default,
+      
+      "/sensing/lidar/top/hesai_ros_wrapper_node: hesai_status": default,
+      "/sensing/lidar/top/hesai_ros_wrapper_node: hesai_ptp": default,
+      "/sensing/lidar/top/hesai_ros_wrapper_node: hesai_temperature": default
+      
+      # "/sensing/lidar/rear/hesai_ros_wrapper_node: hesai_status": default,
+      # "/sensing/lidar/rear/hesai_ros_wrapper_node: hesai_ptp": default,
+      # "/sensing/lidar/rear/hesai_ros_wrapper_node: hesai_temperature": default


### PR DESCRIPTION
This PR update dummy_diag_publisher of sensing for xx1, gen2 vehicle.
Got validated on both psim and jpntaxi no.8