### PR TITLE
fix(aip_x2_gen2_launch): update radar_tracks_msgs_converter_param

### DIFF
--- a/aip_x2_gen2_launch/config/radar_tracks_msgs_converter.param.yaml
+++ b/aip_x2_gen2_launch/config/radar_tracks_msgs_converter.param.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    update_rate_hz: 20.0
+    new_frame_id: "base_link"
+    use_twist_compensation: false
+    use_twist_yaw_compensation: false
+    static_object_speed_threshold: 1.0

--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -5,7 +5,7 @@
   <let name="odometry_topic" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
   <let name="acceleration_topic" value="/localization/acceleration"/>
   <let name="steering_angle_topic" value="/vehicle/status/steering_status_scalar"/>
-  <arg name="radar_tracks_msgs_converter_param_path" default="$(find-pkg-share common_sensor_launch)/config/radar_tracks_msgs_converter.param.yaml"/>
+  <arg name="radar_tracks_msgs_converter_param_path" default="$(find-pkg-share aip_x2_gen2_launch)/config/radar_tracks_msgs_converter.param.yaml"/>
 
   <let name="odometry_throttled_topic" value="$(var odometry_topic)_throttled"/>
   <let name="acceleration_throttled_topic" value="$(var acceleration_topic)_throttled"/>


### PR DESCRIPTION
x2 gen2用にradar_tracks_msgs_converter.param.yamlを追加し、use_twist_compensationをfalseに変更。

related link: https://star4.slack.com/archives/C076ZGRC15X/p1742292524111299
ticket: https://tier4.atlassian.net/browse/RT0-35848