### PR TITLE
feat(aip_x2_gen2_launch): publish gnss orientation to calculate trans…

### DIFF
--- a/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
+++ b/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
@@ -83,7 +83,7 @@
       poscovcartesian: false
       poscovgeodetic: true
       velcovgeodetic: false
-      atteuler: false
+      atteuler: true
       attcoveuler: false
       pose: false
       twist: false

--- a/aip_x2_gen2_launch/launch/gnss.launch.xml
+++ b/aip_x2_gen2_launch/launch/gnss.launch.xml
@@ -11,18 +11,20 @@
       <remap from="navsatfix" to="~/nav_sat_fix"/>
       <remap from="poscovgeodetic" to="~/poscovgeodetic"/>
       <remap from="pvtgeodetic" to="~/pvtgeodetic"/>
+      <remap from="atteuler" to="~/atteuler"/>
     </node>
+
+    <!-- Septentrio Heading Converter -->
+    <node pkg="common_sensor_launch" name="septentrio_heading_converter" exec="septentrio_heading_converter.py"/>
 
     <!-- NavSatFix to MGRS Pose -->
     <include file="$(find-pkg-share autoware_gnss_poser)/launch/gnss_poser.launch.xml">
       <arg name="input_topic_fix" value="septentrio/nav_sat_fix" />
-      <arg name="input_topic_navpvt" value="septentrio/navpvt/unused" />
+      <arg name="input_topic_orientation" value="septentrio/orientation"/>
 
       <arg name="output_topic_gnss_pose" value="pose" />
       <arg name="output_topic_gnss_pose_cov" value="pose_with_covariance" />
       <arg name="output_topic_gnss_fixed" value="fixed" />
-
-      <arg name="use_ublox_receiver" value="true" />
     </include>
 
   </group>


### PR DESCRIPTION
## Description
Related: https://tier4.atlassian.net/browse/RT0-35693

`gnss_poser`でGNSS位置をbase_link位置に座標変換するため、以下の変更を加えました。
- septentrio gnss driverで方位角を出すようにconfigを修正
- septentrio gnss driverから出ている方位角をAutowareで使用する型に変換するため、`septentrio_heading_converter.py`を起動
- `gnss_poserで方位角をsubscribeするように設定

## Tests
- 変更PRを適用して起動できること
- GNSSのatteulerが受信できていること

:warning: ベンチ環境なので、出力はあてにならないと思われる。
```
autoware@main:~$ ros2 topic echo /sensing/gnss/septentrio/atteuler
header:
  stamp:
    sec: 1742780538
    nanosec: 593062375
  frame_id: top_rear/gnss_link
block_header:
  sync_1: 36
  sync_2: 64
  crc: 61400
  id: 5938
  revision: 0
  length: 44
  tow: 92556600
  wnc: 2359
nr_sv: 255
error: 1
mode: 0
heading: .nan
pitch: .nan
roll: .nan
pitch_dot: .nan
roll_dot: .nan
heading_dot: .nan
```

- septentrio/orientationのtopicが出ていること

:warning: ベンチ環境なので、出力はあてにならないと思われる。
```
autoware@main:~$ ros2 topic echo /sensing/gnss/septentrio/orientation
header:
  stamp:
    sec: 1742780660
    nanosec: 393134482
  frame_id: top_rear/gnss_link
orientation:
  orientation:
    x: 0.0
    y: 0.0
    z: .nan
    w: .nan
  rmse_rotation_x: 1.0
  rmse_rotation_y: 1.0
  rmse_rotation_z: 1.0
```

- gnss poserがseptentrio/orientationを受信していること

```
autoware@main:~$ ros2 topic info /sensing/gnss/septentrio/orientation -v
Type: autoware_sensing_msgs/msg/GnssInsOrientationStamped

Publisher count: 1

Node name: septentrio_heading_converter
Node namespace: /sensing/gnss
Topic type: autoware_sensing_msgs/msg/GnssInsOrientationStamped
Endpoint type: PUBLISHER
GID: 01.10.cd.b2.92.13.d3.22.0c.6f.4c.a5.00.00.14.03.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (10)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 2

Node name: rosbag2_recorder
Node namespace: /
Topic type: autoware_sensing_msgs/msg/GnssInsOrientationStamped
Endpoint type: SUBSCRIPTION
GID: 01.10.99.a0.2d.5a.e2.e1.4c.09.6e.f6.00.02.53.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (10)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Node name: gnss_poser
Node namespace: /sensing/gnss
Topic type: autoware_sensing_msgs/msg/GnssInsOrientationStamped
Endpoint type: SUBSCRIPTION
GID: 01.10.f8.aa.ea.5d.14.ba.a6.12.69.69.00.00.1d.04.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (1)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite
```