### PR TITLE
chore(aip_x2_gen2_launch): move gnss to sensors_calibration (#413)

### DIFF
--- a/aip_x2_gen2_description/urdf/sensor_kit.xacro
+++ b/aip_x2_gen2_description/urdf/sensor_kit.xacro
@@ -5,7 +5,6 @@
     <xacro:include filename="$(find pandar_description)/urdf/pandar_ot128.xacro" />
     <xacro:include filename="$(find camera_description)/urdf/monocular_camera.xacro" />
     <xacro:include filename="$(find imu_description)/urdf/imu.xacro" />
-    <xacro:include filename="$(find aip_x2_gen2_description)/urdf/gnss.xacro" />
 
     <xacro:arg name="gpu" default="false" />
     <xacro:arg name="config_dir" default="$(find aip_x2_gen2_description)/config" />
@@ -256,17 +255,6 @@
       fov="1.3"
     />
 
-    <xacro:gnss_macro
-      name="top_front/gnss"
-      parent="sensor_kit_base_link"
-      x="${calibration['sensor_kit_base_link']['top_front/gnss_link']['x']}"
-      y="${calibration['sensor_kit_base_link']['top_front/gnss_link']['y']}"
-      z="${calibration['sensor_kit_base_link']['top_front/gnss_link']['z']}"
-      roll="${calibration['sensor_kit_base_link']['top_front/gnss_link']['roll']}"
-      pitch="${calibration['sensor_kit_base_link']['top_front/gnss_link']['pitch']}"
-      yaw="${calibration['sensor_kit_base_link']['top_front/gnss_link']['yaw']}"
-    />
-
     <!-- rear upper -->
     <xacro:monocular_camera_macro
       name="top_rear_center/camera"
@@ -282,17 +270,6 @@
       width="800"
       height="400"
       fov="1.3"
-    />
-
-    <xacro:gnss_macro
-      name="top_rear/gnss"
-      parent="sensor_kit_base_link"
-      x="${calibration['sensor_kit_base_link']['top_rear/gnss_link']['x']}"
-      y="${calibration['sensor_kit_base_link']['top_rear/gnss_link']['y']}"
-      z="${calibration['sensor_kit_base_link']['top_rear/gnss_link']['z']}"
-      roll="${calibration['sensor_kit_base_link']['top_rear/gnss_link']['roll']}"
-      pitch="${calibration['sensor_kit_base_link']['top_rear/gnss_link']['pitch']}"
-      yaw="${calibration['sensor_kit_base_link']['top_rear/gnss_link']['yaw']}"
     />
 
     <!-- front lower -->

--- a/aip_x2_gen2_description/urdf/sensors.xacro
+++ b/aip_x2_gen2_description/urdf/sensors.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot name="vehicle" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find aip_x2_gen2_description)/urdf/radar.xacro" />
+  <xacro:include filename="$(find aip_x2_gen2_description)/urdf/gnss.xacro" />
   <xacro:arg name="config_dir" default="$(find aip_x2_gen2_description)/config" />
   <xacro:property name="calibration"
     value="${xacro.load_yaml('$(arg config_dir)/sensors_calibration.yaml')}" />
@@ -82,6 +83,28 @@
     roll="${calibration['base_link']['rear_right/radar_link']['roll']}"
     pitch="${calibration['base_link']['rear_right/radar_link']['pitch']}"
     yaw="${calibration['base_link']['rear_right/radar_link']['yaw']}"
+  />
+
+  <xacro:gnss_macro
+    name="top_front/gnss"
+    parent="base_link"
+    x="${calibration['base_link']['top_front/gnss_link']['x']}"
+    y="${calibration['base_link']['top_front/gnss_link']['y']}"
+    z="${calibration['base_link']['top_front/gnss_link']['z']}"
+    roll="${calibration['base_link']['top_front/gnss_link']['roll']}"
+    pitch="${calibration['base_link']['top_front/gnss_link']['pitch']}"
+    yaw="${calibration['base_link']['top_front/gnss_link']['yaw']}"
+  />
+
+  <xacro:gnss_macro
+    name="top_rear/gnss"
+    parent="base_link"
+    x="${calibration['base_link']['top_rear/gnss_link']['x']}"
+    y="${calibration['base_link']['top_rear/gnss_link']['y']}"
+    z="${calibration['base_link']['top_rear/gnss_link']['z']}"
+    roll="${calibration['base_link']['top_rear/gnss_link']['roll']}"
+    pitch="${calibration['base_link']['top_rear/gnss_link']['pitch']}"
+    yaw="${calibration['base_link']['top_rear/gnss_link']['yaw']}"
   />
 
 </robot>


### PR DESCRIPTION
## Description
Cherry-pick following PR to use the latest individual params in X2 v4.0.x
- https://github.com/tier4/aip_launcher/pull/413

## Related
gnss_link has moved here.
https://github.com/tier4/autoware_individual_params.j6_gen2/pull/152



