### PR TITLE
chore: add argument of hires_mode for nebula

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -64,6 +64,7 @@
         <arg name="min_azimuth_deg" value="135.0"/>
         <arg name="max_azimuth_deg" value="225.0"/>
         <arg name="use_dual_return_filter" value="false"/>
+        <arg name="hires_mode" value="false"/>
       </include>
     </group>
 
@@ -106,6 +107,7 @@
         <arg name="min_azimuth_deg" value="225.0"/>
         <arg name="max_azimuth_deg" value="315.0"/>
         <arg name="use_dual_return_filter" value="false"/>
+        <arg name="hires_mode" value="true"/>
       </include>
     </group>
 
@@ -233,6 +235,7 @@
         <arg name="min_azimuth_deg" value="135.0"/>
         <arg name="max_azimuth_deg" value="225.0"/>
         <arg name="use_dual_return_filter" value="false"/>
+        <arg name="hires_mode" value="true"/>
       </include>
     </group>
 
@@ -275,6 +278,7 @@
         <arg name="min_azimuth_deg" value="45.0"/>
         <arg name="max_azimuth_deg" value="135.0"/>
         <arg name="use_dual_return_filter" value="true"/>
+        <arg name="hires_mode" value="true"/>
       </include>
     </group>
 

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -114,6 +114,7 @@ def launch_setup(context, *args, **kwargs):
                     "launch_hw",
                     "udp_only",
                     "point_filters.downsample_mask.path",
+                    "hires_mode",
                 ),
                 "retry_hw": True,
             },
@@ -333,6 +334,7 @@ def generate_launch_description():
     add_launch_arg("output_as_sensor_frame", "True", "output final pointcloud in sensor frame")
     add_launch_arg("use_dual_return_filter", "false")
     add_launch_arg("point_filters.downsample_mask.path", "")
+    add_launch_arg("hires_mode", "true")
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",


### PR DESCRIPTION
## Description
I Added `hires_mode` argument to support nebula v0.2.5.

Current High Resolution Mode settings are here.
| LiDAR Position | High Resolution Mode |
|----------------|----------------------|
| Left           | ON                   |
| Right          | ON                   |
| Front          | ON                   |
| Rear           | OFF                  |


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed this works on logging simulator.
![image](https://github.com/user-attachments/assets/36594d2f-14e1-47b5-ade7-16c9bd013777)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
