### PR TITLE
chore(aip_x2_gen2_launch): use dual_return_filter for rear_upper LiDAR

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -63,7 +63,7 @@
         <arg name="blockage_diagnostics_param_file" value="$(find-pkg-share aip_x2_gen2_launch)/config/blockage_diagnostics_param_file.yaml" />
         <arg name="min_azimuth_deg" value="135.0"/>
         <arg name="max_azimuth_deg" value="225.0"/>
-        <arg name="use_dual_return_filter" value="false"/>
+        <arg name="use_dual_return_filter" value="true"/>
         <arg name="hires_mode" value="false"/>
       </include>
     </group>
@@ -320,7 +320,7 @@
         <arg name="blockage_diagnostics_param_file" value="$(find-pkg-share aip_x2_gen2_launch)/config/blockage_diagnostics_param_file.yaml" />
         <arg name="min_azimuth_deg" value="135.0"/>
         <arg name="max_azimuth_deg" value="225.0"/>
-        <arg name="use_dual_return_filter" value="true"/>
+        <arg name="use_dual_return_filter" value="false"/>
       </include>
     </group>
 


### PR DESCRIPTION
dual_return_filterではQT128(lower系)の雨滴付着時にLiDAR付近の点群でunknownオブジェクトを検出してしまうことがあるため、OT128の一部のみdual_return_filter採用とする。

dual_return_filter採用対象　（その他はring_outlier_filter）
修正前 front_lower, right_upper
修正後 right_upper, rear_upper
 
dual_return_filterが出すvisibility_diagをMRM検知に使いため2つ以上採用したいという背景がある。
[JIRA](https://tier4.atlassian.net/browse/RT0-36137?focusedCommentId=216828)
lsimで効果確認([link](https://tier4.atlassian.net/browse/RT0-36137?focusedCommentId=217039))

本commitマージ後、v0.41ブランチへのcherry-pick, launcherの監視diag変更、dummy_diag修正を行う必要がある