### PR TITLE
fix(aip_x2_gen2_description): move gnss to sensors_calibration.yaml

### DIFF
--- a/aip_x2_gen2_description/config/sensor_kit_calibration.yaml
+++ b/aip_x2_gen2_description/config/sensor_kit_calibration.yaml
@@ -116,13 +116,6 @@ sensor_kit_base_link:
     roll: 0.0
     pitch: 0.0
     yaw: 0.0
-  top_front/gnss_link:
-    x: 0.30133
-    y: -1.07589
-    z: 0.02861
-    roll: 0.0
-    pitch: 0.0
-    yaw: 0.0
 
   # rear upper
   top_rear_center/camera_link:
@@ -130,15 +123,8 @@ sensor_kit_base_link:
     y: -1.20389
     z: -0.14078
     roll: 0.0
-    pitch: 0.0
+    pitch: 0.933278 # 53.50 [deg]
     yaw: 3.141592 # 180 [deg] to turn the connector toward the vehicle
-  top_rear/gnss_link:
-    x: -5.77517
-    y: -1.07589
-    z: 0.02861
-    roll: 0.0
-    pitch: 0.0
-    yaw: 0.0
 
   # front lower
   front_upper/lidar_base_link:

--- a/aip_x2_gen2_description/config/sensors_calibration.yaml
+++ b/aip_x2_gen2_description/config/sensors_calibration.yaml
@@ -55,3 +55,19 @@ base_link:
     roll: 0.0
     pitch: 0.0
     yaw: -1.9189 # 110 [deg]
+
+  # gnss
+  top_rear/gnss_link:
+    x: -1.11273
+    y: 0.00
+    z: 2.81787
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0
+  top_front/gnss_link:
+    x: 4.96377
+    y: 0.0
+    z: 2.81787
+    roll: 0.0
+    pitch: 0.0
+    yaw: 0.0


### PR DESCRIPTION
## Description
Related PR:
- https://github.com/tier4/autoware_individual_params.j6_gen2/pull/152

上記PRでgnssをsensors_calibrationに移動しました。
aip_launcher側でこの対応が漏れていたので、individual paramsのdefaultパラメータをコピーしました。
(ついでに[カメラのpitch修正](https://github.com/tier4/autoware_individual_params.j6_gen2/pull/9)も入っています)