### PR TITLE
fix: modify timestamp offset

### DIFF
--- a/aip_x1_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/aip_x1_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -18,5 +18,5 @@
     output_frame: base_link
     matching_strategy:
       type: advanced
-      lidar_timestamp_offsets: [0.0, 0.03]
+      lidar_timestamp_offsets: [0.0, 0.0]
       lidar_timestamp_noise_window: [0.01, 0.01]


### PR DESCRIPTION
実車評価時に変更したtimestamp offsetの対応を入れ忘れていたので追加
top, frontともにXT32でそれぞれのscan phaseを変えていないので、offsetなしで問題ないと判断しています。
実車、AWSIMにて動作確認済み