### PR TITLE
feat(ring_outlier_filter): update parameters of ring outlier filter

### DIFF
--- a/aip_common_sensor_launch/config/ring_outlier_filter_node.param.yaml
+++ b/aip_common_sensor_launch/config/ring_outlier_filter_node.param.yaml
@@ -1,8 +1,7 @@
 /**:
   ros__parameters:
     distance_ratio: 1.03
-    object_length_threshold: 0.1
-    num_points_threshold: 4
+    object_length_threshold: 0.05
     max_rings_num: 128
     max_points_num_per_ring: 4000
     publish_outlier_pointcloud: false


### PR DESCRIPTION
## What

This PR relates to https://github.com/autowarefoundation/autoware_universe/pull/10537

- Set `object_length_threshold = 0.05` as a default value
- Remove `num_points_threshold`