### PR TITLE
chore(ring_outlier_filter): cherry pick#438

### DIFF
--- a/common_sensor_launch/config/ring_outlier_filter_node.param.yaml
+++ b/common_sensor_launch/config/ring_outlier_filter_node.param.yaml
@@ -1,8 +1,7 @@
 /**:
   ros__parameters:
     distance_ratio: 1.03
-    object_length_threshold: 0.1
-    num_points_threshold: 4
+    object_length_threshold: 0.05
     max_rings_num: 128
     max_points_num_per_ring: 4000
     publish_outlier_pointcloud: false

--- a/common_sensor_launch/config/ring_outlier_filter_node.param.yaml
+++ b/common_sensor_launch/config/ring_outlier_filter_node.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     distance_ratio: 1.03
-    object_length_threshold: 0.05
+    object_length_threshold: 0.1
     max_rings_num: 128
     max_points_num_per_ring: 4000
     publish_outlier_pointcloud: false


### PR DESCRIPTION
## What

#438 をbeta/v0.41に取り込むためのcherry-pick.
XX1などへの影響を考慮し、`object_length_threshold`をこれまでの`0.1`に合わせる。

[tier4/autoware_universeへのPR](https://github.com/tier4/autoware_universe/pull/2011)

[議論SLACK](https://star4.slack.com/archives/C07K1PPNPTR/p1746002482640159)