### PR TITLE
feat(aip_xx1_launch): enable GPU-based pointcloud preprocessor

### DIFF
--- a/aip_common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/aip_common_sensor_launch/launch/nebula_node_container.launch.py
@@ -351,11 +351,12 @@ def make_blockage_diag_nodes(context):
 
 
 def launch_setup(context, *args, **kwargs):
+    # TODO(KYabuuchi): explain the reason of the following code
     # Check that the cuda preprocessor is only used with a shared container
-    if IfCondition(LaunchConfiguration("use_cuda_preprocessor")).evaluate(context):
-        assert IfCondition(LaunchConfiguration("use_shared_container")).evaluate(
-            context
-        ), "The cuda preprocessor should only be used with a shared container."
+    # if IfCondition(LaunchConfiguration("use_cuda_preprocessor")).evaluate(context):
+    #     assert IfCondition(LaunchConfiguration("use_shared_container")).evaluate(
+    #         context
+    #     ), "The cuda preprocessor should only be used with a shared container."
 
     nodes = []
 

--- a/aip_common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/aip_common_sensor_launch/launch/nebula_node_container.launch.py
@@ -351,12 +351,6 @@ def make_blockage_diag_nodes(context):
 
 
 def launch_setup(context, *args, **kwargs):
-    # TODO(KYabuuchi): explain the reason of the following code
-    # Check that the cuda preprocessor is only used with a shared container
-    # if IfCondition(LaunchConfiguration("use_cuda_preprocessor")).evaluate(context):
-    #     assert IfCondition(LaunchConfiguration("use_shared_container")).evaluate(
-    #         context
-    #     ), "The cuda preprocessor should only be used with a shared container."
 
     nodes = []
 
@@ -447,7 +441,7 @@ def generate_launch_description():
     add_launch_arg(
         "use_cuda_preprocessor",
         "False",
-        "Use the cuda implementation of the pointcloud preprocessor. Requires use_shared_container to be enabled",
+        "Use the cuda implementation of the pointcloud preprocessor. When using the CUDA implementations for both concatenation and the preprocessor, requires use_shared_container to be enabled",
     )
     add_launch_arg("ptp_profile", "1588v2")
     add_launch_arg("ptp_transport_type", "L2")

--- a/aip_common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/aip_common_sensor_launch/launch/nebula_node_container.launch.py
@@ -351,7 +351,6 @@ def make_blockage_diag_nodes(context):
 
 
 def launch_setup(context, *args, **kwargs):
-
     nodes = []
 
     nodes.extend(make_common_nodes(context))

--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -9,14 +9,14 @@
   <!-- ====================================================================================
     PLEASE NOTE!
 
-    In XX1, only the pointcloud preprocessor uses the CUDA implementation, 
+    In XX1, only the pointcloud preprocessor uses the CUDA implementation,
     while concatenation uses the CPU implementation.
 
     Although `use_shared_container` is normally required to be true when `use_cuda_preprocessor` is true,
-    in this case, we are intentionally setting them to true and false respectively.  
+    in this case, we are intentionally setting them to true and false respectively.
 
-    For <lidar name>.launch.xml, `use_cuda_preprocessor` is passed as this definition, 
-    but for the pointcloud_preprocessor.launch.py included at the bottom, it is always passed as **FALSE**. 
+    For <lidar name>.launch.xml, `use_cuda_preprocessor` is passed as this definition,
+    but for the pointcloud_preprocessor.launch.py included at the bottom, it is always passed as **FALSE**.
   -->
   <arg name="use_shared_container" default="false"/>
   <arg name="use_cuda_preprocessor" default="true"/>

--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -6,16 +6,21 @@
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <arg name="vehicle_mirror_param_file"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
-  <!-- PLEASE BE VERY CAREFUL!
+  <!-- ====================================================================================
+    PLEASE NOTE!
 
-    On XX1, only the CUDA-based pointcloud preprocessor is used.
-    The concatenation node remains the traditional CPU-based version.
+    In XX1, only the pointcloud preprocessor uses the CUDA implementation, 
+    while concatenation uses the CPU implementation.
 
-    Although use_shared_container is normally required to be true when use_cuda_preprocessor is true,
-    in this case, we are intentionally setting them to true and false respectively.
+    Although `use_shared_container` is normally required to be true when `use_cuda_preprocessor` is true,
+    in this case, we are intentionally setting them to true and false respectively.  
+
+    For <lidar name>.launch.xml, `use_cuda_preprocessor` is passed as this definition, 
+    but for the pointcloud_preprocessor.launch.py included at the bottom, it is always passed as **FALSE**. 
   -->
   <arg name="use_shared_container" default="false"/>
   <arg name="use_cuda_preprocessor" default="true"/>
+  <!-- ==================================================================================== -->
   <arg name="enable_blockage_diag" default="true"/>
   <arg name="udp_only" default="false"/>
 
@@ -144,8 +149,10 @@
       <arg name="base_frame" value="base_link"/>
       <arg name="use_intra_process" value="true"/>
       <arg name="use_multithread" value="true"/>
-      <!-- <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/> -->
+      <!-- PLEASE NOTE! PLEASE READ THE COMMENTS AT THE TOP OF THIS FILES -->
       <arg name="use_cuda_preprocessor" value="false"/>
+      <!-- PLEASE NOTE! PLEASE READ THE COMMENTS AT THE TOP OF THIS FILES -->
+
       <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
     </include>
 

--- a/aip_xx1_launch/launch/lidar.launch.xml
+++ b/aip_xx1_launch/launch/lidar.launch.xml
@@ -6,8 +6,16 @@
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)"/>
   <arg name="vehicle_mirror_param_file"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <!-- PLEASE BE VERY CAREFUL!
+
+    On XX1, only the CUDA-based pointcloud preprocessor is used.
+    The concatenation node remains the traditional CPU-based version.
+
+    Although use_shared_container is normally required to be true when use_cuda_preprocessor is true,
+    in this case, we are intentionally setting them to true and false respectively.
+  -->
   <arg name="use_shared_container" default="false"/>
-  <arg name="use_cuda_preprocessor" default="false"/>
+  <arg name="use_cuda_preprocessor" default="true"/>
   <arg name="enable_blockage_diag" default="true"/>
   <arg name="udp_only" default="false"/>
 
@@ -136,7 +144,8 @@
       <arg name="base_frame" value="base_link"/>
       <arg name="use_intra_process" value="true"/>
       <arg name="use_multithread" value="true"/>
-      <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+      <!-- <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/> -->
+      <arg name="use_cuda_preprocessor" value="false"/>
       <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
     </include>
 


### PR DESCRIPTION
## Description

This PR introduces the CUDA-based pointcloud preprocessor in XX1.
There are two changes:

1. I disblaed a parameter validation in `nebula_node_container` .
(This is because there are valid use cases that violate the validation rules but still function correctly.)

2. I set `use_cuda_preprocessor` to **true** in aip_xx1_launch.

### Parameter's roll
XX1 is the second row setting.

![image](https://github.com/user-attachments/assets/553a6f7a-5a94-426d-a060-91639114d0ca)


## Related links

* [TIER IV INTERNAL TICKET](https://tier4.atlassian.net/browse/RT0-37147)


## How was this PR tested?


I have confirmed that `/sensing/lidar/concatenated/pointcloud` is published as before by `logging_simulator.launch.xml` .
![image](https://github.com/user-attachments/assets/5b2c4978-8a80-4c90-b9c9-1a1a2793eb23)

And all `cuda_pointcloud_preprocessor_node` are launched correctly.
![image](https://github.com/user-attachments/assets/143c682d-7bbf-4722-bbce-dbb2c24c2ec3)


## Notes for reviewers

I will cherry-pick this PR to `tier4/universe` too.