### PR TITLE
feat(aip_xx1_gen2): enable CUDA-based pointcloud preprocessor

### DIFF
--- a/aip_xx1_gen2_launch/launch/lidar.launch.py
+++ b/aip_xx1_gen2_launch/launch/lidar.launch.py
@@ -91,6 +91,7 @@ def load_sub_launches_from_yaml(context, *args, **kwargs):
 
     path_dictionary = generate_launch_dictionary()
 
+    # Create base parameters which is common for all lidars
     base_parameters = {}
     base_parameters["host_ip"] = LaunchConfiguration("host_ip").perform(context)
     base_parameters["vehicle_mirror_param_file"] = LaunchConfiguration(
@@ -107,6 +108,15 @@ def load_sub_launches_from_yaml(context, *args, **kwargs):
     )
     base_parameters["return_mode"] = LaunchConfiguration("return_mode").perform(context)
 
+    # Set CUDA-related parameters
+    base_parameters["use_shared_container"] = LaunchConfiguration("use_shared_container").perform(
+        context
+    )
+    base_parameters["use_cuda_preprocessor"] = LaunchConfiguration("use_cuda_preprocessor").perform(
+        context
+    )
+
+    # Create launch actions for each lidar
     sub_launch_actions = []
     for launch in config["launches"]:
         launch_parameters = deepcopy(base_parameters)
@@ -123,6 +133,7 @@ def load_sub_launches_from_yaml(context, *args, **kwargs):
         )
         sub_launch_actions.append(sub_launch_action)
 
+    # Create launch action for pointcloud preprocessor, which contains only the pointcloud concatenation
     processor_dict = config["preprocessor"]
     sub_launch_actions.append(
         IncludeLaunchDescription(
@@ -147,6 +158,10 @@ def load_sub_launches_from_yaml(context, *args, **kwargs):
                     "publish_synchronized_pointcloud",
                     str(processor_dict["publish_synchronized_pointcloud"]),
                 ),
+                # PLEASE NOTE!
+                # We intentionally set `use_cuda_preprocessor` to **FALSE**,
+                # because we do not want to use GPU implementation for pointcloud concatenation.
+                ("use_cuda_preprocessor", "False"),
             ],
         )
     )
@@ -183,6 +198,25 @@ def generate_launch_description():
     add_launch_arg("pointcloud_container_name", "pointcloud_container")
     add_launch_arg("enable_blockage_diag", "false")
     add_launch_arg("return_mode", "Dual")
+
+    # ====================================================================================
+    # PLEASE NOTE!
+
+    # In XX1, only the pointcloud preprocessor uses the CUDA implementation,
+    # while concatenation uses the CPU implementation.
+
+    # Although `use_shared_container` is normally required to be true when `use_cuda_preprocessor` is true,
+    # in this case, we are intentionally setting them to true and false respectively.
+
+    # For <lidar name>.launch.xml, `use_cuda_preprocessor` is passed as this definition in `load_sub_launches_from_yaml()`,
+    # but for the pointcloud_preprocessor.launch.py, it is always passed as **FALSE**.
+
+    # Currently, to perform all pre-processing including concatenation on the GPU,
+    # all nodes must be placed in a single container.
+    # However, this approach lacks fault tolerance, so will not be adopted for a while.
+    add_launch_arg("use_shared_container", "false")
+    add_launch_arg("use_cuda_preprocessor", "true")
+    # ====================================================================================
 
     # Create launch description with the config_file argument
     ld = LaunchDescription(launch_arguments)


### PR DESCRIPTION
## Description

* Introduce CUDA-preprocessor in aip_xx1 **_gen2** as same as https://github.com/tier4/aip_launcher/pull/453

## Related links
* [TIER IV INTERNAL TICKET](https://tier4.atlassian.net/browse/RT0-37147)

## How was this PR tested?

<!-- 
> [!CAUTION]
 $\large\text{THIS PR IS NOT TESTED IN A REAL VEHICLE.}$ 
-->

### in the real vehicle

Now it worked well. 

> [!NOTE]
> At the beginning of the experiment, there was a bug where unintended undistortion was applied, but after updating Nebula, the timestamps were corrected and undistortion is fixed.

<img src=https://github.com/user-attachments/assets/2ba53891-82dc-4417-8093-e999079baf49 width=400>

[TIER IV INTERNAL LINK]( https://star4.slack.com/archives/C076E8EBJTG/p1749544742931749?thread_ts=1749186163.583199&cid=C076E8EBJTG)


### logging_simualtor.launch.xml

I have confirmed that `/sensing/lidar/concatenated/pointcloud` is published as before by `logging_simulator.launch.xml` .
![image](https://github.com/user-attachments/assets/073abe4f-4991-4519-8dbf-01054825adc6)

And all cuda_pointcloud_preprocessor_node are launched correctly.

![image](https://github.com/user-attachments/assets/aea2b46c-6e49-46a8-97a4-12b357775b69)

## Notes for reviewers

I will cherry-pick this PR to `tier4/universe` too.