### PR TITLE
chore(nebula_node_container): add hires_mode for OT128

### DIFF
--- a/aip_common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/aip_common_sensor_launch/launch/nebula_node_container.launch.py
@@ -140,6 +140,7 @@ def make_nebula_nodes(context):
                         "ptp_switch_type",
                         "ptp_domain",
                         "diag_span",
+                        "hires_mode",
                     ),
                 },
             ],
@@ -424,6 +425,7 @@ def generate_launch_description():
     add_launch_arg("input_frame", LaunchConfiguration("base_frame"), "use for cropbox")
     add_launch_arg("output_frame", LaunchConfiguration("base_frame"), "use for cropbox")
     add_launch_arg("diag_span", "1000")
+    add_launch_arg("hires_mode", "true", "enable high resolution mode in OT128")
     add_launch_arg("advanced_diagnostics", "false")
     add_launch_arg("use_multithread", "False", "use multithread")
     add_launch_arg("use_intra_process", "False", "use ROS 2 component container communication")


### PR DESCRIPTION
## Description
To apply a hotfix for Nebula, it is necessary to update the Nebula version.  https://github.com/tier4/pilot-auto/pull/1483
However, this version update involves adding parameter, so I add a parameter `hires_mode` to `nebula_node_container`.

> [!NOTE]
> The `hires_mode` parameter is only needed for the Hesai OT128 LiDAR.
> And it  has **no effect** when passed to other LiDAR models.

> [!NOTE]
> The default value of `hires_mode` is set to `true`, meaning high resolution mode is enabled by default.

Currently, only `x2_gen2` and `xx1 gen2` use the OT128 in `aip_launcher`.  

## Test performed

Please see https://github.com/tier4/pilot-auto/pull/1483

## Related Links 
* https://github.com/tier4/pilot-auto/pull/1483
* https://github.com/tier4/nebula/pull/294