### PR TITLE
fix(septentrio_heading_converter): handle NaN heading values in orientation conversion

### DIFF
--- a/common_sensor_launch/scripts/septentrio_heading_converter.py
+++ b/common_sensor_launch/scripts/septentrio_heading_converter.py
@@ -61,6 +61,10 @@ class OrientationConverter(Node):
         if attitude_msg.heading < 0:
             return
 
+        # When heading is NaN, it means the heading is not available.
+        if np.isnan(attitude_msg.heading):
+            return
+
         orientation_msg = GnssInsOrientationStamped()
         orientation_msg.header = attitude_msg.header
 


### PR DESCRIPTION

Added a check to return early if the heading value from the attitude message is NaN, indicating that the heading is not available. This prevents potential errors during orientation conversion.

origin PR https://github.com/tier4/aip_launcher/pull/448

https://star4.slack.com/archives/C07DMS06H6U/p1749628925460909?thread_ts=1749536389.230689&cid=C07DMS06H6U