### PR TITLE
feat(aip_x2_gen2_launch): add simple tracked object merger configuration and launch integration

### DIFF
--- a/aip_x2_gen2_launch/config/simple_tracked_object_merger.param.yaml
+++ b/aip_x2_gen2_launch/config/simple_tracked_object_merger.param.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    update_rate_hz: 20.0
+    new_frame_id: "map"
+    timeout_threshold: 1.0
+    input_topics: ["/sensing/radar/front_center/tracked_objects", "/sensing/radar/rear_center/tracked_objects"]
+    uuid_mapping_cleanup_threshold: 30.0 # in sec.

--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -200,5 +200,11 @@
       <param from="$(var merger_param_path)"/>
     </node>
 
+    <let name="tracked_objects_merger_param_path" value="$(find-pkg-share aip_x2_gen2_launch)/config/simple_tracked_object_merger.param.yaml"/>
+    <node pkg="autoware_simple_object_merger" exec="simple_tracked_object_merger_node" name="simple_tracked_object_merger" output="screen">
+      <remap from="~/output/objects" to="tracked_objects"/>
+      <param from="$(var tracked_objects_merger_param_path)"/>
+    </node>
+
   </group>
 </launch>


### PR DESCRIPTION
enable radar tracked object merger via simple object merger

This modification should be used with update of the simple object merger
https://github.com/autowarefoundation/autoware_universe/pull/10785