### PR TITLE
feat(autoware_velodyne_minitor): disable autoware velodyne monitor

### DIFF
--- a/aip_common_sensor_launch/launch/velodyne_VLP16.launch.xml
+++ b/aip_common_sensor_launch/launch/velodyne_VLP16.launch.xml
@@ -52,9 +52,4 @@
     <arg name="udp_only" value="$(var udp_only)"/>
   </include>
 
-  <!-- Velodyne Monitor -->
-  <include file="$(find-pkg-share autoware_velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
-    <arg name="ip_address" value="$(var sensor_ip)"/>
-  </include>
-
 </launch>

--- a/aip_common_sensor_launch/launch/velodyne_VLP32C.launch.xml
+++ b/aip_common_sensor_launch/launch/velodyne_VLP32C.launch.xml
@@ -52,9 +52,4 @@
     <arg name="udp_only" value="$(var udp_only)"/>
   </include>
 
-  <!-- Velodyne Monitor -->
-  <include file="$(find-pkg-share autoware_velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
-    <arg name="ip_address" value="$(var sensor_ip)"/>
-  </include>
-
 </launch>

--- a/aip_common_sensor_launch/launch/velodyne_VLS128.launch.xml
+++ b/aip_common_sensor_launch/launch/velodyne_VLS128.launch.xml
@@ -52,9 +52,4 @@
     <arg name="udp_only" value="$(var udp_only)"/>
   </include>
 
-  <!-- Velodyne Monitor -->
-  <include file="$(find-pkg-share autoware_velodyne_monitor)/launch/velodyne_monitor.launch.xml" if="$(var launch_driver)">
-    <arg name="ip_address" value="$(var sensor_ip)"/>
-  </include>
-
 </launch>

--- a/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -16,9 +16,21 @@
       # "blockage: blockage_validation": default
 
       # velodyne
-      "velodyne_monitor: velodyne_connection": default
-      "velodyne_monitor: velodyne_temperature": default
-      "velodyne_monitor: velodyne_rpm": default
+      "/sensing/lidar/top/velodne_ros_wrapper_node: velodyne_status": default
+      "/sensing/lidar/top/velodne_ros_wrapper_node: velodyne_temperature": default
+      "/sensing/lidar/top/velodne_ros_wrapper_node: velodyne_rpm": default
+
+      "/sensing/lidar/right/velodne_ros_wrapper_node: velodyne_status": default
+      "/sensing/lidar/right/velodne_ros_wrapper_node: velodyne_temperature": default
+      "/sensing/lidar/right/velodne_ros_wrapper_node: velodyne_rpm": default
+
+      "/sensing/lidar/left/velodne_ros_wrapper_node: velodyne_status": default
+      "/sensing/lidar/left/velodne_ros_wrapper_node: velodyne_temperature": default
+      "/sensing/lidar/left/velodne_ros_wrapper_node: velodyne_rpm": default
+
+      "/sensing/lidar/rear/velodne_ros_wrapper_node: velodyne_status": default
+      "/sensing/lidar/rear/velodne_ros_wrapper_node: velodyne_temperature": default
+      "/sensing/lidar/rear/velodne_ros_wrapper_node: velodyne_rpm": default
 
       # gnss
       # "connection: gnss_connection": default

--- a/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -16,21 +16,21 @@
       # "blockage: blockage_validation": default
 
       # velodyne
-      "/sensing/lidar/top/velodne_ros_wrapper_node: velodyne_status": default
-      "/sensing/lidar/top/velodne_ros_wrapper_node: velodyne_temperature": default
-      "/sensing/lidar/top/velodne_ros_wrapper_node: velodyne_rpm": default
+      "/sensing/lidar/top/velodyne_ros_wrapper_node: velodyne_status": default
+      "/sensing/lidar/top/velodyne_ros_wrapper_node: velodyne_temperature": default
+      "/sensing/lidar/top/velodyne_ros_wrapper_node: velodyne_rpm": default
 
-      "/sensing/lidar/right/velodne_ros_wrapper_node: velodyne_status": default
-      "/sensing/lidar/right/velodne_ros_wrapper_node: velodyne_temperature": default
-      "/sensing/lidar/right/velodne_ros_wrapper_node: velodyne_rpm": default
+      "/sensing/lidar/right/velodyne_ros_wrapper_node: velodyne_status": default
+      "/sensing/lidar/right/velodyne_ros_wrapper_node: velodyne_temperature": default
+      "/sensing/lidar/right/velodyne_ros_wrapper_node: velodyne_rpm": default
 
-      "/sensing/lidar/left/velodne_ros_wrapper_node: velodyne_status": default
-      "/sensing/lidar/left/velodne_ros_wrapper_node: velodyne_temperature": default
-      "/sensing/lidar/left/velodne_ros_wrapper_node: velodyne_rpm": default
+      "/sensing/lidar/left/velodyne_ros_wrapper_node: velodyne_status": default
+      "/sensing/lidar/left/velodyne_ros_wrapper_node: velodyne_temperature": default
+      "/sensing/lidar/left/velodyne_ros_wrapper_node: velodyne_rpm": default
 
-      "/sensing/lidar/rear/velodne_ros_wrapper_node: velodyne_status": default
-      "/sensing/lidar/rear/velodne_ros_wrapper_node: velodyne_temperature": default
-      "/sensing/lidar/rear/velodne_ros_wrapper_node: velodyne_rpm": default
+      "/sensing/lidar/rear/velodyne_ros_wrapper_node: velodyne_status": default
+      "/sensing/lidar/rear/velodyne_ros_wrapper_node: velodyne_temperature": default
+      "/sensing/lidar/rear/velodyne_ros_wrapper_node: velodyne_rpm": default
 
       # gnss
       # "connection: gnss_connection": default


### PR DESCRIPTION
## Description

In the recent versions of pilot-auto, nebula v0.2.6 or later is used.
Since nebula includes Velodyne hardware monitoring functionality, there is no need to launch `autoware_velodyne_monitor` in aip_launch.
So I disabled it.

> [!NOTE]
> Within this repository, only aip_xx1 uses the velodyne lidar. So, this does not affect to other product.

Additionally, the dummy_diag_publisher was also updated to conform to nebula's diagnostics format.
You can see the nebula's diagnostics format below link.
* https://github.com/tier4/nebula/pull/281

## Related PR

* https://github.com/tier4/autoware_launch.xx1/pull/1353