### PR TITLE
fix(aip_xx1_gen2): erase corner radar entry in object_merger

### DIFF
--- a/aip_xx1_gen2_launch/config/radar_simple_object_merger.param.yaml
+++ b/aip_xx1_gen2_launch/config/radar_simple_object_merger.param.yaml
@@ -3,4 +3,4 @@
     update_rate_hz: 20.0
     new_frame_id: "base_link"
     timeout_threshold: 1.0
-    input_topics: ["/sensing/radar/front_center/detected_objects", "/sensing/radar/front_left/detected_objects", "/sensing/radar/rear_left/detected_objects", "/sensing/radar/rear_center/detected_objects", "/sensing/radar/rear_right/detected_objects", "/sensing/radar/front_right/detected_objects"]
+    input_topics: ["/sensing/radar/front_center/detected_objects", "/sensing/radar/rear_center/detected_objects"]


### PR DESCRIPTION
## Description

Currently, the corner radars do not publish objects. So I erased them from radar_simple_object_merger.

> [!NOTE]
> Until now, any radars are not used at all in XX1 Gen2. :sweat_smile: 
> Because simple_object_merger will wait for all data is ready [[ref]](https://github.com/tier4/autoware_universe/blob/v0.48.0/perception/autoware_simple_object_merger/src/simple_object_merger_node.cpp#L196-L212)

I will cherry-pick this to `beta/v0.48`, `beta/v044` and `beta/v0.41` .

## related PR
* https://github.com/tier4/nebula/pull/337