### PR TITLE
feat(x2gen2): add Nebula diagnostic parameters

### DIFF
--- a/aip_x2_gen2_launch/config/nebula_hesai_common.param.yaml
+++ b/aip_x2_gen2_launch/config/nebula_hesai_common.param.yaml
@@ -1,0 +1,15 @@
+/**:
+  ros__parameters:
+    ptp_profile: automotive
+    ptp_domain: 0
+    ptp_transport_type: L2
+    ptp_switch_type: NON_TSN
+    ptp_lock_threshold: 100
+    diagnostics:
+      pointcloud_publish_rate:
+        frequency_ok:
+          min_hz: 9.5
+          max_hz: 10.5
+        frequency_warn:
+          min_hz: 9.0
+          max_hz: 11.0

--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -64,6 +64,7 @@
         <arg name="max_azimuth_deg" value="225.0"/>
         <arg name="use_dual_return_filter" value="true"/>
         <arg name="hires_mode" value="false"/>
+        <arg name="diagnostics.packet_loss.error_threshold" value="20"/>
       </include>
     </group>
 
@@ -104,6 +105,7 @@
         <arg name="max_azimuth_deg" value="315.0"/>
         <arg name="use_dual_return_filter" value="false"/>
         <arg name="hires_mode" value="true"/>
+        <arg name="diagnostics.packet_loss.error_threshold" value="20"/>
       </include>
     </group>
 
@@ -143,6 +145,7 @@
         <arg name="min_azimuth_deg" value="135.0"/>
         <arg name="max_azimuth_deg" value="225.0"/>
         <arg name="use_dual_return_filter" value="false"/>
+        <arg name="diagnostics.packet_loss.error_threshold" value="20"/>
       </include>
     </group>
 
@@ -182,6 +185,7 @@
         <arg name="min_azimuth_deg" value="225.0"/>
         <arg name="max_azimuth_deg" value="315.0"/>
         <arg name="use_dual_return_filter" value="false"/>
+        <arg name="diagnostics.packet_loss.error_threshold" value="20"/>
       </include>
     </group>
 
@@ -223,6 +227,7 @@
         <arg name="max_azimuth_deg" value="225.0"/>
         <arg name="use_dual_return_filter" value="false"/>
         <arg name="hires_mode" value="true"/>
+        <arg name="diagnostics.packet_loss.error_threshold" value="20"/>
       </include>
     </group>
 
@@ -263,6 +268,7 @@
         <arg name="max_azimuth_deg" value="135.0"/>
         <arg name="use_dual_return_filter" value="true"/>
         <arg name="hires_mode" value="true"/>
+        <arg name="diagnostics.packet_loss.error_threshold" value="20"/>
       </include>
     </group>
 
@@ -302,6 +308,7 @@
         <arg name="min_azimuth_deg" value="135.0"/>
         <arg name="max_azimuth_deg" value="225.0"/>
         <arg name="use_dual_return_filter" value="false"/>
+        <arg name="diagnostics.packet_loss.error_threshold" value="20"/>
       </include>
     </group>
 
@@ -341,6 +348,7 @@
         <arg name="min_azimuth_deg" value="45.0"/>
         <arg name="max_azimuth_deg" value="135.0"/>
         <arg name="use_dual_return_filter" value="false"/>
+        <arg name="diagnostics.packet_loss.error_threshold" value="20"/>
       </include>
     </group>
 

--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -44,11 +44,6 @@
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.3"/>
         <arg name="max_range" value="230.0"/>
-        <arg name="ptp_profile" value="automotive"/>
-        <arg name="ptp_transport_type" value="L2"/>
-        <arg name="ptp_switch_type" value="NON_TSN"/>
-        <arg name="ptp_domain" value="0"/>
-        <arg name="ptp_lock_threshold" value="100"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
@@ -89,11 +84,6 @@
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.3"/>
         <arg name="max_range" value="230.0"/>
-        <arg name="ptp_profile" value="automotive"/>
-        <arg name="ptp_transport_type" value="L2"/>
-        <arg name="ptp_switch_type" value="NON_TSN"/>
-        <arg name="ptp_domain" value="0"/>
-        <arg name="ptp_lock_threshold" value="100"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
@@ -134,11 +124,6 @@
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.1"/>
         <arg name="max_range" value="50.0"/>
-        <arg name="ptp_profile" value="automotive"/>
-        <arg name="ptp_transport_type" value="L2"/>
-        <arg name="ptp_switch_type" value="NON_TSN"/>
-        <arg name="ptp_domain" value="0"/>
-        <arg name="ptp_lock_threshold" value="100"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
@@ -178,11 +163,6 @@
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.1"/>
         <arg name="max_range" value="50.0"/>
-        <arg name="ptp_profile" value="automotive"/>
-        <arg name="ptp_transport_type" value="L2"/>
-        <arg name="ptp_switch_type" value="NON_TSN"/>
-        <arg name="ptp_domain" value="0"/>
-        <arg name="ptp_lock_threshold" value="100"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
@@ -223,11 +203,6 @@
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.3"/>
         <arg name="max_range" value="230.0"/>
-        <arg name="ptp_profile" value="automotive"/>
-        <arg name="ptp_transport_type" value="L2"/>
-        <arg name="ptp_switch_type" value="NON_TSN"/>
-        <arg name="ptp_domain" value="0"/>
-        <arg name="ptp_lock_threshold" value="100"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
@@ -268,11 +243,6 @@
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.3"/>
         <arg name="max_range" value="230.0"/>
-        <arg name="ptp_profile" value="automotive"/>
-        <arg name="ptp_transport_type" value="L2"/>
-        <arg name="ptp_switch_type" value="NON_TSN"/>
-        <arg name="ptp_domain" value="0"/>
-        <arg name="ptp_lock_threshold" value="100"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
@@ -313,11 +283,6 @@
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.1"/>
         <arg name="max_range" value="50.0"/>
-        <arg name="ptp_profile" value="automotive"/>
-        <arg name="ptp_transport_type" value="L2"/>
-        <arg name="ptp_switch_type" value="NON_TSN"/>
-        <arg name="ptp_domain" value="0"/>
-        <arg name="ptp_lock_threshold" value="100"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
@@ -357,11 +322,6 @@
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.1"/>
         <arg name="max_range" value="50.0"/>
-        <arg name="ptp_profile" value="automotive"/>
-        <arg name="ptp_transport_type" value="L2"/>
-        <arg name="ptp_switch_type" value="NON_TSN"/>
-        <arg name="ptp_domain" value="0"/>
-        <arg name="ptp_lock_threshold" value="100"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -88,6 +88,10 @@ def launch_setup(context, *args, **kwargs):
         plugin=sensor_make + "RosWrapper",
         name=sensor_make.lower() + "_ros_wrapper_node",
         parameters=[
+            ParameterFile(
+                LaunchConfiguration("nebula_common_config_file").perform(context),
+                allow_substs=True,
+            ),
             {
                 "sensor_model": sensor_model,
                 **create_parameter_dict(
@@ -108,11 +112,6 @@ def launch_setup(context, *args, **kwargs):
                     "gnss_port",
                     "packet_mtu_size",
                     "setup_sensor",
-                    "ptp_profile",
-                    "ptp_transport_type",
-                    "ptp_switch_type",
-                    "ptp_domain",
-                    "ptp_lock_threshold",
                     "diag_span",
                     "calibration_file",
                     "launch_hw",
@@ -159,7 +158,10 @@ def launch_setup(context, *args, **kwargs):
         plugin="autoware::pointcloud_preprocessor::DistortionCorrectorComponent",
         name="distortion_corrector_node",
         remappings=[
-            ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
+            (
+                "~/input/twist",
+                "/sensing/vehicle_velocity_converter/twist_with_covariance",
+            ),
             ("~/input/imu", "/sensing/imu/imu_data"),
             ("~/input/pointcloud", "self_cropped/pointcloud_ex"),
             ("~/output/pointcloud", "rectified/pointcloud_ex"),
@@ -295,6 +297,14 @@ def generate_launch_description():
         )
 
     add_launch_arg("sensor_model", description="sensor model name")
+    add_launch_arg(
+        "nebula_common_config_file",
+        [
+            FindPackageShare("aip_x2_gen2_launch"),
+            "/config/nebula_hesai_common.param.yaml",
+        ],
+        description="file containing parameters common to all Nebula instances",
+    )
     add_launch_arg("config_file", "", description="sensor configuration file")
     add_launch_arg(
         "agnocast_heaphook_path",
@@ -312,7 +322,6 @@ def generate_launch_description():
     add_launch_arg("host_ip", "255.255.255.255", "host ip address")
     add_launch_arg("sync_angle", "0")
     add_launch_arg("cut_angle", "0.0")
-    add_launch_arg("ptp_lock_threshold", "100")
     add_launch_arg("udp_only", "false")
     add_launch_arg("base_frame", "base_link", "base frame id")
     add_launch_arg("min_range", "0.3", "minimum view range for Velodyne sensors")

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -118,6 +118,7 @@ def launch_setup(context, *args, **kwargs):
                     "udp_only",
                     "point_filters.downsample_mask.path",
                     "hires_mode",
+                    "diagnostics.packet_loss.error_threshold",
                 ),
                 "retry_hw": True,
             },
@@ -373,6 +374,7 @@ def generate_launch_description():
     add_launch_arg("use_dual_return_filter", "false")
     add_launch_arg("point_filters.downsample_mask.path", "")
     add_launch_arg("hires_mode", "true")
+    add_launch_arg("diagnostics.packet_loss.error_threshold")
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",


### PR DESCRIPTION
Port of #463, #465 to the tier4/universe branch.

To summarize:
- added a new `nebula_hesai_common.param.yaml` for params common to all LiDARS of X2gen2
- moved al `ptp_` params to the new common file
- added a new `diagnostics.packet_loss.error_threshold` param to all LiDARS (set to `20` for now)
- added the `diagnostics.pointcloud_publish_rate` subtree of params to the common file