### PR TITLE
chore(aip_x2_gen2_launch): is_main_ecu variable to use different imu

### DIFF
--- a/aip_x2_gen2_launch/launch/imu.launch.xml
+++ b/aip_x2_gen2_launch/launch/imu.launch.xml
@@ -7,6 +7,9 @@
     <arg name="interface" default="fintekcan3"/>
     <arg name="receiver_interval_sec" default="0.01"/>
     <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
+    <arg name="is_main_ecu" default="true" />
+    <let name="imu_frame_id" value="top_front_left/imu_link" if="$(var is_main_ecu)"/>
+    <let name="imu_frame_id" value="top_front_right/imu_link" unless="$(var is_main_ecu)"/>
 
     <group>
       <push-ros-namespace namespace="tamagawa"/>
@@ -17,7 +20,7 @@
       <node pkg="tamagawa_imu_driver" name="tag_can_driver" exec="tag_can_driver" if="$(var launch_driver)">
         <remap from="/can/imu" to="from_can_bus"/>
         <remap from="imu/data_raw" to="imu_raw"/>
-        <param name="imu_frame_id" value="top_front_left/imu_link"/>
+        <param name="imu_frame_id" value="$(var imu_frame_id)"/>
       </node>
     </group>
 


### PR DESCRIPTION
IMUのframe_idをmainとsubでそれぞれ、top_front_left, top_front_rightを使い分けます。
lsimで動作確認済みです。