### PR TITLE
feat(aip_x2/xx1_gen2_launch): add simple tracked object merger configuration and launch integration (#481)

### DIFF
--- a/aip_x2_gen2_launch/config/simple_tracked_object_merger.param.yaml
+++ b/aip_x2_gen2_launch/config/simple_tracked_object_merger.param.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    update_rate_hz: 20.0
+    new_frame_id: "map"
+    timeout_threshold: 1.0
+    input_topics: ["/sensing/radar/front_center/tracked_objects", "/sensing/radar/rear_center/tracked_objects"]
+    uuid_mapping_cleanup_threshold: 30.0 # in sec.

--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -200,5 +200,11 @@
       <param from="$(var merger_param_path)"/>
     </node>
 
+    <let name="tracked_objects_merger_param_path" value="$(find-pkg-share aip_x2_gen2_launch)/config/simple_tracked_object_merger.param.yaml"/>
+    <node pkg="autoware_simple_object_merger" exec="simple_tracked_object_merger_node" name="simple_tracked_object_merger" output="screen">
+      <remap from="~/output/objects" to="tracked_objects"/>
+      <param from="$(var tracked_objects_merger_param_path)"/>
+    </node>
+
   </group>
 </launch>

--- a/aip_x2_gen2_launch/package.xml
+++ b/aip_x2_gen2_launch/package.xml
@@ -16,7 +16,7 @@
   <exec_depend>autoware_gnss_poser</exec_depend>
   <exec_depend>autoware_imu_corrector</exec_depend>
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
-  <exec_depend>autoware_radar_tracks_msgs_converter</exec_depend>
+  <exec_depend>autoware_radar_objects_adapter</exec_depend>
   <exec_depend>autoware_simple_object_merger</exec_depend>
   <exec_depend>autoware_topic_state_monitor</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>

--- a/aip_xx1_gen2_launch/config/ARS548.param.yaml
+++ b/aip_xx1_gen2_launch/config/ARS548.param.yaml
@@ -11,6 +11,7 @@
     configuration_host_port: 42401
     configuration_sensor_port: 42101
     use_sensor_time: false
+    radar_info_rate_subsample: 10
     configuration_vehicle_length: 4.4 #  0.8 + 2.75 + 0.85
     configuration_vehicle_width: 1.695 # 1.485 + 0.105 + 0.105
     configuration_vehicle_height: 2.5

--- a/aip_xx1_gen2_launch/config/simple_tracked_object_merger.param.yaml
+++ b/aip_xx1_gen2_launch/config/simple_tracked_object_merger.param.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    update_rate_hz: 20.0
+    new_frame_id: "map"
+    timeout_threshold: 1.0
+    input_topics: ["/sensing/radar/front_center/detected_objects", "/sensing/radar/rear_center/detected_objects"]
+    uuid_mapping_cleanup_threshold: 30.0 # in sec.

--- a/aip_xx1_gen2_launch/config/simple_tracked_object_merger.param.yaml
+++ b/aip_xx1_gen2_launch/config/simple_tracked_object_merger.param.yaml
@@ -3,5 +3,5 @@
     update_rate_hz: 20.0
     new_frame_id: "map"
     timeout_threshold: 1.0
-    input_topics: ["/sensing/radar/front_center/detected_objects", "/sensing/radar/rear_center/detected_objects"]
+    input_topics: ["/sensing/radar/front_center/tracked_objects", "/sensing/radar/rear_center/tracked_objects"]
     uuid_mapping_cleanup_threshold: 30.0 # in sec.

--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -88,7 +88,7 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-        
+
         <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
           <arg name="input_radar_objects" value="radar_objects"/>
           <arg name="input_radar_info" value="radar_info"/>
@@ -120,7 +120,7 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-        
+
         <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
           <arg name="input_radar_objects" value="radar_objects"/>
           <arg name="input_radar_info" value="radar_info"/>
@@ -152,7 +152,7 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-        
+
         <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
           <arg name="input_radar_objects" value="radar_objects"/>
           <arg name="input_radar_info" value="radar_info"/>
@@ -184,7 +184,7 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-        
+
         <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
           <arg name="input_radar_objects" value="radar_objects"/>
           <arg name="input_radar_info" value="radar_info"/>
@@ -216,7 +216,7 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-        
+
         <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
           <arg name="input_radar_objects" value="radar_objects"/>
           <arg name="input_radar_info" value="radar_info"/>

--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -250,6 +250,13 @@
       <remap from="~/output/objects" to="detected_objects"/>
       <param from="$(var merger_param_path)"/>
     </node>
+
+    <let name="tracked_objects_merger_param_path" value="$(find-pkg-share aip_xx1_gen2_launch)/config/simple_tracked_object_merger.param.yaml"/>
+    <node pkg="autoware_simple_object_merger" exec="simple_tracked_object_merger_node" name="simple_tracked_object_merger" output="screen">
+      <remap from="~/output/objects" to="tracked_objects"/>
+      <param from="$(var tracked_objects_merger_param_path)"/>
+    </node>
+
   </group>
 
 </launch>

--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -56,16 +56,13 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-      </group>
 
-      <group>
-        <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
-          <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
-          <arg name="output/radar_detected_objects" value="detected_objects"/>
-          <arg name="output/radar_tracked_objects" value="tracked_objects"/>
-          <arg name="use_twist_compensation" value="false"/>
-          <arg name="param_path" value="$(var radar_tracks_msgs_converter_param_path)"/>
+        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
+          <arg name="input_radar_objects" value="radar_objects"/>
+          <arg name="input_radar_info" value="radar_info"/>
+          <arg name="output_detections" value="detected_objects"/>
+          <arg name="output_tracks" value="tracked_objects"/>
+          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
       </group>
     </group>
@@ -91,16 +88,13 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-      </group>
-
-      <group>
-        <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
-          <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
-          <arg name="output/radar_detected_objects" value="detected_objects"/>
-          <arg name="output/radar_tracked_objects" value="tracked_objects"/>
-          <arg name="use_twist_compensation" value="false"/>
-          <arg name="param_path" value="$(var radar_tracks_msgs_converter_param_path)"/>
+        
+        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
+          <arg name="input_radar_objects" value="radar_objects"/>
+          <arg name="input_radar_info" value="radar_info"/>
+          <arg name="output_detections" value="detected_objects"/>
+          <arg name="output_tracks" value="tracked_objects"/>
+          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
       </group>
     </group>
@@ -126,16 +120,13 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-      </group>
-
-      <group>
-        <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
-          <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
-          <arg name="output/radar_detected_objects" value="detected_objects"/>
-          <arg name="output/radar_tracked_objects" value="tracked_objects"/>
-          <arg name="use_twist_compensation" value="false"/>
-          <arg name="param_path" value="$(var radar_tracks_msgs_converter_param_path)"/>
+        
+        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
+          <arg name="input_radar_objects" value="radar_objects"/>
+          <arg name="input_radar_info" value="radar_info"/>
+          <arg name="output_detections" value="detected_objects"/>
+          <arg name="output_tracks" value="tracked_objects"/>
+          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
       </group>
     </group>
@@ -161,16 +152,13 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-      </group>
-
-      <group>
-        <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
-          <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
-          <arg name="output/radar_detected_objects" value="detected_objects"/>
-          <arg name="output/radar_tracked_objects" value="tracked_objects"/>
-          <arg name="use_twist_compensation" value="false"/>
-          <arg name="param_path" value="$(var radar_tracks_msgs_converter_param_path)"/>
+        
+        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
+          <arg name="input_radar_objects" value="radar_objects"/>
+          <arg name="input_radar_info" value="radar_info"/>
+          <arg name="output_detections" value="detected_objects"/>
+          <arg name="output_tracks" value="tracked_objects"/>
+          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
       </group>
     </group>
@@ -196,16 +184,13 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-      </group>
-
-      <group>
-        <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
-          <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
-          <arg name="output/radar_detected_objects" value="detected_objects"/>
-          <arg name="output/radar_tracked_objects" value="tracked_objects"/>
-          <arg name="use_twist_compensation" value="false"/>
-          <arg name="param_path" value="$(var radar_tracks_msgs_converter_param_path)"/>
+        
+        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
+          <arg name="input_radar_objects" value="radar_objects"/>
+          <arg name="input_radar_info" value="radar_info"/>
+          <arg name="output_detections" value="detected_objects"/>
+          <arg name="output_tracks" value="tracked_objects"/>
+          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
       </group>
     </group>
@@ -231,15 +216,13 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-      </group>
-
-      <group>
-        <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
-          <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
-          <arg name="output/radar_detected_objects" value="detected_objects"/>
-          <arg name="output/radar_tracked_objects" value="tracked_objects"/>
-          <arg name="param_path" value="$(var radar_tracks_msgs_converter_param_path)"/>
+        
+        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
+          <arg name="input_radar_objects" value="radar_objects"/>
+          <arg name="input_radar_info" value="radar_info"/>
+          <arg name="output_detections" value="detected_objects"/>
+          <arg name="output_tracks" value="tracked_objects"/>
+          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
       </group>
     </group>

--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -64,6 +64,7 @@
           <arg name="output_tracks" value="tracked_objects"/>
           <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
+
       </group>
     </group>
 
@@ -96,6 +97,7 @@
           <arg name="output_tracks" value="tracked_objects"/>
           <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
+
       </group>
     </group>
 
@@ -128,6 +130,7 @@
           <arg name="output_tracks" value="tracked_objects"/>
           <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
+
       </group>
     </group>
 
@@ -160,6 +163,7 @@
           <arg name="output_tracks" value="tracked_objects"/>
           <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
+
       </group>
     </group>
 
@@ -192,6 +196,7 @@
           <arg name="output_tracks" value="tracked_objects"/>
           <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
+
       </group>
     </group>
 
@@ -224,6 +229,7 @@
           <arg name="output_tracks" value="tracked_objects"/>
           <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
         </include>
+
       </group>
     </group>
 

--- a/aip_xx1_gen2_launch/package.xml
+++ b/aip_xx1_gen2_launch/package.xml
@@ -15,7 +15,7 @@
   <exec_depend>autoware_gnss_poser</exec_depend>
   <exec_depend>autoware_imu_corrector</exec_depend>
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
-  <exec_depend>autoware_radar_tracks_msgs_converter</exec_depend>
+  <exec_depend>autoware_radar_objects_adapter</exec_depend>
   <exec_depend>autoware_simple_object_merger</exec_depend>
   <exec_depend>autoware_vehicle_velocity_converter</exec_depend>
   <exec_depend>pacmod3</exec_depend>


### PR DESCRIPTION
Integration for radar tracked object pipeline.

https://github.com/autowarefoundation/autoware_universe/issues/10679

