### PR TITLE
feat(aip_xx1_gen2_launch): add lidar_gen2_1.yaml

### DIFF
--- a/aip_xx1_gen2_launch/config/lidar_gen2_1.yaml
+++ b/aip_xx1_gen2_launch/config/lidar_gen2_1.yaml
@@ -1,0 +1,65 @@
+launches:
+  - sensor_type: hesai_OT128
+    namespace: top
+    parameters:
+      max_range: 300.0
+      sensor_frame: hesai_top
+      sensor_ip: 192.168.1.201
+      data_port: 2368
+      sync_angle: 180
+      cut_angle: 180.0
+  - sensor_type: hesai_XT32
+    namespace: front_left
+    parameters:
+      max_range: 80.0
+      sensor_frame: hesai_front_left
+      sensor_ip: 192.168.1.21
+      data_port: 2369
+      sync_angle: 50
+      cut_angle: 320.0
+      cloud_min_angle: 50
+      cloud_max_angle: 320
+  - sensor_type: hesai_XT32
+    namespace: front_right
+    parameters:
+      max_range: 80.0
+      sensor_frame: hesai_front_right
+      sensor_ip: 192.168.1.22
+      data_port: 2370
+      sync_angle: 310
+      cut_angle: 310.0
+      cloud_min_angle: 40
+      cloud_max_angle: 310
+  - sensor_type: hesai_XT32
+    namespace: side_left
+    parameters:
+      max_range: 10.0
+      sensor_frame: hesai_side_left
+      sensor_ip: 192.168.1.23
+      data_port: 2371
+      sync_angle: 90
+      cut_angle: 270.0
+      cloud_min_angle: 90
+      cloud_max_angle: 270
+  - sensor_type: hesai_XT32
+    namespace: side_right
+    parameters:
+      max_range: 10.0
+      sensor_frame: hesai_side_right
+      sensor_ip: 192.168.1.24
+      data_port: 2372
+      sync_angle: 270
+      cut_angle: 270.0
+      cloud_min_angle: 90
+      cloud_max_angle: 270
+  - sensor_type: hesai_XT32
+    namespace: rear
+    parameters:
+      max_range: 1.5
+      sensor_frame: hesai_rear
+      sensor_ip: 192.168.1.25
+      data_port: 2373
+      sync_angle: 270
+      cut_angle: 270.0
+      cloud_min_angle: 90
+      cloud_max_angle: 270

--- a/aip_xx1_gen2_launch/launch/lidar.launch.py
+++ b/aip_xx1_gen2_launch/launch/lidar.launch.py
@@ -180,19 +180,23 @@ def generate_launch_description():
     launch_arguments = []
     config_file_arg = DeclareLaunchArgument(
         "config_file",
-        default_value=PythonExpression([
-            "'",
-            os.path.join(
-                get_package_share_directory("aip_xx1_gen2_launch"), "config", "lidar_gen2.yaml"
-            ),
-            "' if (lambda x: x.isdigit() and int(x) in [1, 5, 8])('",
-            EnvironmentVariable("VEHICLE_ID", default_value="0"),
-            "') else '",
-            os.path.join(
-                get_package_share_directory("aip_xx1_gen2_launch"), "config", "lidar_gen2_1.yaml"
-            ),
-            "'"
-        ]),
+        default_value=PythonExpression(
+            [
+                "'",
+                os.path.join(
+                    get_package_share_directory("aip_xx1_gen2_launch"), "config", "lidar_gen2.yaml"
+                ),
+                "' if (lambda x: x.isdigit() and int(x) in [1, 5, 8])('",
+                EnvironmentVariable("VEHICLE_ID", default_value="0"),
+                "') else '",
+                os.path.join(
+                    get_package_share_directory("aip_xx1_gen2_launch"),
+                    "config",
+                    "lidar_gen2_1.yaml",
+                ),
+                "'",
+            ]
+        ),
         description="Path to the configuration file",
     )
     launch_arguments.append(config_file_arg)

--- a/aip_xx1_gen2_launch/launch/lidar.launch.py
+++ b/aip_xx1_gen2_launch/launch/lidar.launch.py
@@ -28,7 +28,6 @@ from launch.launch_description_sources import AnyLaunchDescriptionSource
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import EnvironmentVariable
 from launch.substitutions import LaunchConfiguration
-from launch.substitutions import PythonExpression
 from launch_ros.actions import PushRosNamespace
 import yaml
 
@@ -178,32 +177,19 @@ def load_sub_launches_from_yaml(context, *args, **kwargs):
 def generate_launch_description():
     # Define launch arguments
     launch_arguments = []
-    config_file_arg = DeclareLaunchArgument(
-        "config_file",
-        default_value=PythonExpression(
-            [
-                "'",
-                os.path.join(
-                    get_package_share_directory("aip_xx1_gen2_launch"), "config", "lidar_gen2.yaml"
-                ),
-                "' if (lambda x: x.isdigit() and int(x) in [1, 5, 8])('",
-                EnvironmentVariable("VEHICLE_ID", default_value="0"),
-                "') else '",
-                os.path.join(
-                    get_package_share_directory("aip_xx1_gen2_launch"),
-                    "config",
-                    "lidar_gen2_1.yaml",
-                ),
-                "'",
-            ]
-        ),
-        description="Path to the configuration file",
+
+    default_config_file_path = os.path.join(
+        get_package_share_directory("aip_xx1_gen2_launch"), "config", "lidar_gen2.yaml"
     )
-    launch_arguments.append(config_file_arg)
 
     def add_launch_arg(name: str, default_value=None, **kwargs):
         launch_arguments.append(DeclareLaunchArgument(name, default_value=default_value, **kwargs))
 
+    add_launch_arg(
+        "config_file",
+        default_config_file_path,
+        description="Path to the configuration file",
+    )
     add_launch_arg("launch_driver", "true")
     add_launch_arg("launch_hw_monitor", "true", description="launch hardware monitor")
     add_launch_arg("host_ip", "192.168.1.11")

--- a/aip_xx1_gen2_launch/launch/lidar.launch.py
+++ b/aip_xx1_gen2_launch/launch/lidar.launch.py
@@ -28,6 +28,7 @@ from launch.launch_description_sources import AnyLaunchDescriptionSource
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import EnvironmentVariable
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PythonExpression
 from launch_ros.actions import PushRosNamespace
 import yaml
 
@@ -179,9 +180,19 @@ def generate_launch_description():
     launch_arguments = []
     config_file_arg = DeclareLaunchArgument(
         "config_file",
-        default_value=os.path.join(
-            get_package_share_directory("aip_xx1_gen2_launch"), "config", "lidar_gen2.yaml"
-        ),
+        default_value=PythonExpression([
+            "'",
+            os.path.join(
+                get_package_share_directory("aip_xx1_gen2_launch"), "config", "lidar_gen2.yaml"
+            ),
+            "' if (lambda x: x.isdigit() and int(x) in [1, 5, 8])('",
+            EnvironmentVariable("VEHICLE_ID", default_value="0"),
+            "') else '",
+            os.path.join(
+                get_package_share_directory("aip_xx1_gen2_launch"), "config", "lidar_gen2_1.yaml"
+            ),
+            "'"
+        ]),
         description="Path to the configuration file",
     )
     launch_arguments.append(config_file_arg)

--- a/aip_xx1_gen2_launch/launch/sensing.launch.xml
+++ b/aip_xx1_gen2_launch/launch/sensing.launch.xml
@@ -9,11 +9,17 @@
   <group>
 
     <!-- LiDAR Driver -->
+    <let name="is_gen2_0" value="$(eval &quot;'$(var vehicle_id)' in ['1', '5', '8']&quot;)"/>
+    <let name="lidar_config_file" value="$(find-pkg-share aip_xx1_gen2_launch)/config/lidar_gen2.yaml" if="$(var is_gen2_0)"/>
+    <let name="lidar_config_file" value="$(find-pkg-share aip_xx1_gen2_launch)/config/lidar_gen2_1.yaml" unless="$(var is_gen2_0)"/>
+    <log message="lidar_config_file: $(var lidar_config_file)"/>
+
     <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/lidar.launch.py">
       <arg name="launch_driver" value="$(var launch_driver)" />
       <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)" />
       <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
+      <arg name="config_file" value="$(var lidar_config_file)"/>
     </include>
 
     <!-- Camera Driver -->


### PR DESCRIPTION
## Description

The original XX1 Gen2.0 Top LiDAR is 20 deg rotated while the latest one is not rotated.
This PR adds the new lidar configuration: `lidar_gen2_1.yaml` in addition to  `lidar_gen2.yaml`
The difference between them is `sync_angle` and `cut_angle`.
The `VEHICLE_ID: 1,5,8` use the default `lidar_gen2.yaml` while others use `lidar_gen2_1.yaml`.
Though hyper parameters contaminate the file, I didn't come up with the better idea.

[Original top LiDAR]
- `VEHICLE_ID: 1,5,8`
- `lidar_gen2.yaml`

<img src="https://github.com/user-attachments/assets/7ce3b050-6bdb-450e-9ee7-6e55e5d00477"  width="50%">

[The latest top LiDAR]
- `lidar_gen2_1.yaml`
- `VEHICLE_ID` other Gen2.0
<img src="https://github.com/user-attachments/assets/67a67ecc-0d20-4b41-848a-ca773514b5bd" width="50%">

See the detail: [XX1 Gen2.0 LiDAR Camera sync chart](https://app.diagrams.net/?splash=0#G1bqXIg6xBzAxTdmcwebQdw6nO0U9aCYaL#%7B%22pageId%22%3A%22hF0MPtWqjfvqvMuOM7mS%22%7D)



## Test
I tested this PR with logging_simulator.
According to the VEHICLE_ID, it reads either `lidar_gen2.yaml` or `lidar_gen2_1.yaml`
To test this, I temporary added the debug print.

1. `lidar_gen2.yaml` 
```
$ echo $VEHICLE_ID
5

$ ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/odaiba_beta vehicle_model:=jpntaxi sensor_model:=aip_xx1_gen2  |grep config
Default config_file path: [<launch.substitutions.python_expression.PythonExpression object at 0x7103b83c5810>]
Loading YAML configuration file: /home/shmpwk/xx1/pilot-auto.xx1.v0.49/install/aip_xx1_gen2_launch/share/aip_xx1_gen2_launch/config/lidar_gen2.yaml
```

2. `lidar_gen2_1.yaml` 
```
$ echo $VEHICLE_ID
CS20-001

$ ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/odaiba_beta vehicle_model:=jpntaxi sensor_model:=aip_xx1_gen2  |grep config
Default config_file path: [<launch.substitutions.python_expression.PythonExpression object at 0x7b6c8474cb20>]
Loading YAML configuration file: /home/shmpwk/xx1/pilot-auto.xx1.v0.49/install/aip_xx1_gen2_launch/share/aip_xx1_gen2_launch/config/lidar_gen2_1.yaml

```