### PR TITLE
fix(aip_xx1_gen2):use rear lidar in gen2 vehicle except for 8

### DIFF
--- a/aip_xx1_gen2_description/config/sensors_calibration.yaml
+++ b/aip_xx1_gen2_description/config/sensors_calibration.yaml
@@ -23,13 +23,14 @@ base_link:
     pitch: 0.0 # Design Value
     yaw: 0.69813132679 # Design Value
     type: pandar_xt32
-  # velodyne_rear_base_link: #unused
-  #   x: -0.358
-  #   y: 0.0
-  #   z: 1.631
-  #   roll: -0.02
-  #   pitch: 0.7281317
-  #   yaw: 3.141592
+  hesai_rear_base_link:
+    x: -0.433
+    y: 0.000
+    z: 1.613
+    roll: 0.728
+    pitch: 0.0
+    yaw: -1.570
+    type: pandar_xt32
   front_center/radar_link:
     x: 3.520 # Design Value
     y: 0.0 # Design Value

--- a/aip_xx1_gen2_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/aip_xx1_gen2_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -12,14 +12,15 @@
     synchronized_pointcloud_postfix: pointcloud
     input_twist_topic_type: twist
     input_topics: [
-                    "/sensing/lidar/top/pointcloud_before_sync", # 0.99
-                    "/sensing/lidar/front_left/pointcloud_before_sync",  # 0.99
-                    "/sensing/lidar/front_right/pointcloud_before_sync", # 0.99
-                    "/sensing/lidar/side_left/pointcloud_before_sync",   # 0.99
-                    "/sensing/lidar/side_right/pointcloud_before_sync",  # 0.99
+                    "/sensing/lidar/top/pointcloud_before_sync",
+                    "/sensing/lidar/front_left/pointcloud_before_sync",
+                    "/sensing/lidar/front_right/pointcloud_before_sync",
+                    "/sensing/lidar/side_left/pointcloud_before_sync",
+                    "/sensing/lidar/side_right/pointcloud_before_sync",
+                    "/sensing/lidar/rear/pointcloud_before_sync",
                 ]
     output_frame: base_link
     matching_strategy:
       type: advanced
-      lidar_timestamp_offsets: [0.0, 0.0, 0.025, 0.0, 0.05]
-      lidar_timestamp_noise_window: [0.01, 0.01, 0.01, 0.01, 0.01]
+      lidar_timestamp_offsets: [0.0, 0.0, 0.025, 0.0, 0.05, 0.05]
+      lidar_timestamp_noise_window: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]

--- a/aip_xx1_gen2_launch/config/lidar_gen2.yaml
+++ b/aip_xx1_gen2_launch/config/lidar_gen2.yaml
@@ -52,20 +52,14 @@ launches:
       cut_angle: 270.0
       cloud_min_angle: 90
       cloud_max_angle: 270
-
-preprocessor:
-  input_topics:
-    - /sensing/lidar/top/pointcloud_before_sync
-    - /sensing/lidar/side_left/pointcloud_before_sync
-    - /sensing/lidar/side_right/pointcloud_before_sync
-    - /sensing/lidar/front_left/pointcloud_before_sync
-    - /sensing/lidar/front_right/pointcloud_before_sync
-  input_offset:
-    - 0.035
-    - 0.025
-    - 0.025
-    - 0.025
-    - 0.025
-  timeout_sec: 0.095
-  input_twist_topic_type: twist
-  publish_synchronized_pointcloud: true
+  - sensor_type: hesai_XT32
+    namespace: rear
+    parameters:
+      max_range: 1.5
+      sensor_frame: hesai_rear
+      sensor_ip: 192.168.1.25
+      data_port: 2373
+      sync_angle: 270
+      cut_angle: 270.0
+      cloud_min_angle: 90
+      cloud_max_angle: 270

--- a/aip_xx1_gen2_launch/launch/lidar.launch.py
+++ b/aip_xx1_gen2_launch/launch/lidar.launch.py
@@ -82,12 +82,25 @@ def generate_launch_dictionary():
     return path_dictionary
 
 
+def erase_rear_lidar_entry_depending_on_vehicle_id(config: dict, vehicle_id: str) -> dict:
+    # Only NO. 8 vehicle does not have a rear lidar, so we erase the rear lidar entry.
+    if vehicle_id != "8":
+        return config
+
+    config["launches"] = [sensor for sensor in config["launches"] if sensor["namespace"] != "rear"]
+    return config
+
+
 def load_sub_launches_from_yaml(context, *args, **kwargs):
     def load_yaml(yaml_file_path):
         with open(LaunchConfiguration(yaml_file_path).perform(context), "r") as f:
             return yaml.safe_load(f)
 
     config = load_yaml("config_file")
+
+    # Remove the rear lidar entry from the parameter file if the vehicle does not have a rear lidar
+    vehicle_id = LaunchConfiguration("vehicle_id").perform(context)
+    config = erase_rear_lidar_entry_depending_on_vehicle_id(config, vehicle_id)
 
     path_dictionary = generate_launch_dictionary()
 
@@ -137,6 +150,7 @@ def load_sub_launches_from_yaml(context, *args, **kwargs):
                 ("base_frame", "base_link"),
                 ("use_multithread", "true"),
                 ("use_intra_process", "true"),
+                ("vehicle_id", LaunchConfiguration("vehicle_id")),
                 ("use_pointcloud_container", LaunchConfiguration("use_pointcloud_container")),
                 ("pointcloud_container_name", LaunchConfiguration("pointcloud_container_name")),
                 ("input_topics", join_list_of_arguments(processor_dict["input_topics"])),

--- a/aip_xx1_gen2_launch/launch/lidar.launch.py
+++ b/aip_xx1_gen2_launch/launch/lidar.launch.py
@@ -136,7 +136,6 @@ def load_sub_launches_from_yaml(context, *args, **kwargs):
         )
         sub_launch_actions.append(sub_launch_action)
 
-    processor_dict = config["preprocessor"]
     sub_launch_actions.append(
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource(
@@ -153,14 +152,6 @@ def load_sub_launches_from_yaml(context, *args, **kwargs):
                 ("vehicle_id", LaunchConfiguration("vehicle_id")),
                 ("use_pointcloud_container", LaunchConfiguration("use_pointcloud_container")),
                 ("pointcloud_container_name", LaunchConfiguration("pointcloud_container_name")),
-                ("input_topics", join_list_of_arguments(processor_dict["input_topics"])),
-                ("input_offset", join_list_of_arguments(processor_dict["input_offset"])),
-                ("timeout_sec", str(processor_dict["timeout_sec"])),
-                ("input_twist_topic_type", str(processor_dict["input_twist_topic_type"])),
-                (
-                    "publish_synchronized_pointcloud",
-                    str(processor_dict["publish_synchronized_pointcloud"]),
-                ),
             ],
         )
     )

--- a/aip_xx1_gen2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_xx1_gen2_launch/launch/pointcloud_preprocessor.launch.py
@@ -21,19 +21,39 @@ from launch.actions import OpaqueFunction
 from launch.actions import SetLaunchConfiguration
 from launch.conditions import IfCondition
 from launch.conditions import UnlessCondition
+from launch.substitutions import EnvironmentVariable
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
-from launch_ros.parameter_descriptions import ParameterFile
+import yaml
+
+
+def erase_rear_lidar_entry_depending_on_vehicle_id(config: dict, vehicle_id: str) -> dict:
+    # Only NO. 8 vehicle does not have a rear lidar, so we erase the rear lidar entry.
+    if vehicle_id != "8":
+        return config
+
+    # Acquire the index of the rear lidar entry
+    rear_lidar_index = config["input_topics"].index("/sensing/lidar/rear/pointcloud_before_sync")
+
+    # Remove all items related to the rear lidar
+    config["input_topics"].pop(rear_lidar_index)
+    config["matching_strategy"]["lidar_timestamp_offsets"].pop(rear_lidar_index)
+    config["matching_strategy"]["lidar_timestamp_noise_window"].pop(rear_lidar_index)
+
+    return config
 
 
 def launch_setup(context, *args, **kwargs):
-    # concatenate node parameters
-    concatenate_and_time_sync_node_param = ParameterFile(
-        param_file=LaunchConfiguration("concatenate_and_time_sync_node_param_path").perform(
-            context
-        ),
-        allow_substs=True,
+    # Load concatenate node parameters as YAML
+    with open(
+        LaunchConfiguration("concatenate_and_time_sync_node_param_path").perform(context), "r"
+    ) as f:
+        concatenate_and_time_sync_node_param = yaml.safe_load(f)["/**"]["ros__parameters"]
+
+    # Remove the rear lidar entry from the parameter file if the vehicle does not have a rear lidar
+    concatenate_and_time_sync_node_param = erase_rear_lidar_entry_depending_on_vehicle_id(
+        concatenate_and_time_sync_node_param, LaunchConfiguration("vehicle_id").perform(context)
     )
 
     # set concat filter as a component
@@ -71,7 +91,10 @@ def generate_launch_description():
     add_launch_arg("use_intra_process", "False")
     add_launch_arg("pointcloud_container_name", "pointcloud_container")
     add_launch_arg("individual_container_name", "concatenate_container")
-
+    add_launch_arg(
+        "vehicle_id",
+        default_value=EnvironmentVariable("VEHICLE_ID", default_value="default"),
+    )
     add_launch_arg(
         "concatenate_and_time_sync_node_param_path",
         os.path.join(


### PR DESCRIPTION
* cherry-pick  #468

After merging this PR, the `/tf_static` of the rear lidar will be published in all xx1_gen2 vehicle except for `vehicle_id=8`.

> ## Description 
> 
> I added **rear lidar** entry in aip_xx1_gen2_launch.
> Among the our XX1 vehicles, only No.8 does not have a rear lidar. Therefore, the rear lidar entry is erased only when the VEHICLE_ID is 8.
> 
> > [!NOTE]
> > Honestly, I do not think it is a good idea to change the behavior in aip_launcher based on a specific VEHICLE_ID... :upside_down_face: 
>  
> ## Detail
> ### `sensors_calibration.yaml`
> * Added `hesai_rear_base_link` to publish the `tf_statc`.
> * The default calibration value is quoted from https://github.com/tier4/autoware_individual_params.jpntaxi/pull/129/files
> ---
> 
> ### `lidar_gen2.yaml`
> 
> - Added an entry for the **rear lidar**.  
> - Removed parameters related to the preprocessor. These parameters have not been used .
>   Settings for concatenation are now described in `concatenate_and_time_sync_node.param.yaml`.
> 
> ---
> 
> ### `concatenate_and_time_sync_node.param.yaml`
> 
> - Added an entry for the **rear lidar**.  
> - Set the **timestamp_offset** for the rear lidar to `0.050`.  
>   This is because the rear lidar has a timestamp of `ToS + 0.050s`
> ---
> 
> ### `lidar.launch.py`
> 
> - When the `vehicle_id` is `8`, the **rear entry** in `lidar_gen2.yaml` is removed.  
> - Removed parameters that were passed to `pointcloud_preprocessor.launch.py` but were not being used.
> 
> ---
> 
> ### `pointcloud_preprocessor.launch.py`
> 
> - When the `vehicle_id` is `8`, the **rear entry** in `lidar_gen2.yaml` is removed.
> 
> ---
> 
> ## Related links
> 
> Other PR
> * https://github.com/tier4/autoware_individual_params.jpntaxi/pull/129
> 
> Synchronization document [TIER IV INTERNAL LINK]
> ![image](https://github.com/user-attachments/assets/8072b5e0-d757-413a-839b-09f0957d4001)


