### PR TITLE
fix(aip_x2_gen2_description): imu roll

### DIFF
--- a/aip_x2_gen2_description/config/sensors_calibration.yaml
+++ b/aip_x2_gen2_description/config/sensors_calibration.yaml
@@ -77,13 +77,13 @@ base_link:
     x: 5.22444
     y: 0.07615
     z: 2.72762
-    roll: 0.0
+    roll: 3.141592
     pitch: 0.0
     yaw: 0.0
   top_front_right/imu_link:
     x: 5.22444
     y: -0.06385
     z: 2.72762
-    roll: 0.0
+    roll: 3.141592
     pitch: 0.0
     yaw: 0.0


### PR DESCRIPTION
## Description
以下PRでIMUのrolleが180度逆向きになっていたので、修正します。
- https://github.com/tier4/autoware_individual_params.j6_gen2/pull/215
- https://github.com/tier4/aip_launcher/pull/499


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

### Before (間違っている状態)
<img width="2624" height="1558" alt="image" src="https://github.com/user-attachments/assets/dd0792b3-e644-46d4-bb56-4ba6710c8ad1" />

### After (上下逆だが、これで正しい状態)
<img width="2624" height="1558" alt="image" src="https://github.com/user-attachments/assets/f5cc83d5-1574-442c-b2fb-945ce27675c1" />



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
