### PR TITLE
feat(aip_x2_gen2_lanuch): support polar_voxel_outlier_filter

### DIFF
--- a/aip_common_sensor_launch/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/aip_common_sensor_launch/config/polar_voxel_outlier_filter_node.param.yaml
@@ -1,0 +1,16 @@
+/**:
+  ros__parameters:
+    radius_resolution_m: 0.2        # Resolution in radial direction (meters)
+    azimuth_resolution_rad: 0.025    # Resolution in azimuth direction (radians, ~1 degree)
+    elevation_resolution_rad: 0.05  # Resolution in elevation direction (radians, ~1 degree)
+    voxel_points_threshold: 2     # Minimum points required per voxel
+    min_radius_m: 0.5               # Minimum radius to consider (meters)
+    max_radius_m: 300.0             # Maximum radius to consider (meters)
+    use_return_type_classification: true  # Whether to use return type classification
+    filter_secondary_returns: false      # Whether to filter secondary returns (keep only primary when true)
+    secondary_noise_threshold: 4         # Threshold for classifying primary vs secondary returns
+    primary_return_types: [1, 6, 10]     # Return types considered as primary returns
+    filter_ratio_error_threshold: 0.7     # Error threshold for filter ratio diagnostics
+    filter_ratio_warn_threshold: 0.3      # Warning threshold for filter ratio diagnostics
+    visibility_error_threshold: 0.5       # Error threshold for visibility diagnostics
+    visibility_warn_threshold: 0.7

--- a/aip_common_sensor_launch/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/aip_common_sensor_launch/config/polar_voxel_outlier_filter_node.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    radius_resolution_m: 0.2        # Resolution in radial direction (meters)
+    radial_resolution_m: 0.2        # Resolution in radial direction (meters)
     azimuth_resolution_rad: 0.025    # Resolution in azimuth direction (radians, ~1 degree)
     elevation_resolution_rad: 0.05  # Resolution in elevation direction (radians, ~1 degree)
     voxel_points_threshold: 2     # Minimum points required per voxel

--- a/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
@@ -1,0 +1,16 @@
+/**:
+  ros__parameters:
+    radius_resolution_m: 0.2        # Resolution in radial direction (meters)
+    azimuth_resolution_rad: 0.025    # Resolution in azimuth direction (radians, ~1 degree)
+    elevation_resolution_rad: 0.05  # Resolution in elevation direction (radians, ~1 degree)
+    voxel_points_threshold: 2     # Minimum points required per voxel
+    min_radius_m: 0.5               # Minimum radius to consider (meters)
+    max_radius_m: 300.0             # Maximum radius to consider (meters)
+    use_return_type_classification: true  # Whether to use return type classification
+    filter_secondary_returns: false      # Whether to filter secondary returns (keep only primary when true)
+    secondary_noise_threshold: 4         # Threshold for classifying primary vs secondary returns
+    primary_return_types: [1, 6, 10]     # Return types considered as primary returns
+    filter_ratio_error_threshold: 0.7     # Error threshold for filter ratio diagnostics
+    filter_ratio_warn_threshold: 0.3      # Warning threshold for filter ratio diagnostics
+    visibility_error_threshold: 0.5       # Error threshold for visibility diagnostics
+    visibility_warn_threshold: 0.7

--- a/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
@@ -6,11 +6,12 @@
     voxel_points_threshold: 2     # Minimum points required per voxel
     min_radius_m: 0.5               # Minimum radius to consider (meters)
     max_radius_m: 300.0             # Maximum radius to consider (meters)
+    visibility_estimation_max_range_m: 20.0  # Maximum range for visibility estimation (meters)
     use_return_type_classification: true  # Whether to use return type classification
     filter_secondary_returns: false      # Whether to filter secondary returns (keep only primary when true)
     secondary_noise_threshold: 4         # Threshold for classifying primary vs secondary returns
-    primary_return_types: [1, 6, 10]     # Return types considered as primary returns
+    primary_return_types: [1, 6, 8, 10]     # Return types considered as primary returns
     filter_ratio_error_threshold: 0.7     # Error threshold for filter ratio diagnostics
     filter_ratio_warn_threshold: 0.3      # Warning threshold for filter ratio diagnostics
     visibility_error_threshold: 0.5       # Error threshold for visibility diagnostics
-    visibility_warn_threshold: 0.7
+    visibility_warn_threshold: 0.6

--- a/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    radius_resolution_m: 0.2        # Resolution in radial direction (meters)
+    radial_resolution_m: 0.2        # Resolution in radial direction (meters)
     azimuth_resolution_rad: 0.025    # Resolution in azimuth direction (radians, ~1 degree)
     elevation_resolution_rad: 0.05  # Resolution in elevation direction (radians, ~1 degree)
     voxel_points_threshold: 2     # Minimum points required per voxel

--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -16,6 +16,13 @@
   <arg name="dual_return_filter_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/dual_return_filter.param.yaml"/>
   <arg name="ring_outlier_filter_node_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/ring_outlier_filter_node.param.yaml"/>
   <arg name="enable_blockage_diag" default="true"/>
+  <!-- <arg name="polar_voxel_filter" default="disable"> -->
+  <arg name="polar_voxel_filter" default="cuda">
+    <choice value="disable"/>
+    <choice value="cpu"/>
+    <choice value="cuda"/>
+  </arg>
+  <arg name="polar_voxel_outlier_filter_node_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/polar_voxel_outlier_filter_node.param.yaml"/>
 
   <group>
     <push-ros-namespace namespace="lidar" />

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -217,50 +217,54 @@ def make_preprocessor_nodes(context):
         context
     )
 
-    if not use_dual_return_filter:
-        nodes.append(
-            ComposableNode(
-                package="autoware_pointcloud_preprocessor",
-                plugin="autoware::pointcloud_preprocessor::RingOutlierFilterComponent",
-                name="ring_outlier_filter",
-                remappings=[
-                    ("input", "rectified/pointcloud_ex"),
-                    ("output", "pointcloud_before_sync"),
-                ],
-                parameters=[
-                    ring_outlier_filter_node_param,
-                    ring_outlier_output_frame,
-                    {"is_agnocast_publish_node": True},
-                ],
-                extra_arguments=[
-                    {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
-                ],
+    voxel_outlier_filter_arg = LaunchConfiguration("polar_voxel_filter").perform(context)
+    use_voxel_outlier_filter = (voxel_outlier_filter_arg in ['cpu', 'cuda'])
+
+    if not use_voxel_outlier_filter:
+        if not use_dual_return_filter:
+            nodes.append(
+                ComposableNode(
+                    package="autoware_pointcloud_preprocessor",
+                    plugin="autoware::pointcloud_preprocessor::RingOutlierFilterComponent",
+                    name="ring_outlier_filter",
+                    remappings=[
+                        ("input", "rectified/pointcloud_ex"),
+                        ("output", "pointcloud_before_sync"),
+                    ],
+                    parameters=[
+                        ring_outlier_filter_node_param,
+                        ring_outlier_output_frame,
+                        {"is_agnocast_publish_node": True},
+                    ],
+                    extra_arguments=[
+                        {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
+                    ],
+                )
             )
-        )
-    else:
-        nodes.append(
-            ComposableNode(
-                package="autoware_pointcloud_preprocessor",
-                plugin="autoware::pointcloud_preprocessor::DualReturnOutlierFilterComponent",
-                name="dual_return_filter",
-                remappings=[
-                    ("input", "rectified/pointcloud_ex"),
-                    ("output", "pointcloud_before_sync"),
-                ],
-                parameters=[
-                    {
-                        "vertical_bins": LaunchConfiguration("vertical_bins"),
-                        "min_azimuth_deg": LaunchConfiguration("min_azimuth_deg"),
-                        "max_azimuth_deg": LaunchConfiguration("max_azimuth_deg"),
-                        "is_agnocast_publish_node": True,
-                    }
-                ]
-                + [load_composable_node_param(context, "dual_return_filter_param_file")],
-                extra_arguments=[
-                    {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
-                ],
+        else:
+            nodes.append(
+                ComposableNode(
+                    package="autoware_pointcloud_preprocessor",
+                    plugin="autoware::pointcloud_preprocessor::DualReturnOutlierFilterComponent",
+                    name="dual_return_filter",
+                    remappings=[
+                        ("input", "rectified/pointcloud_ex"),
+                        ("output", "pointcloud_before_sync"),
+                    ],
+                    parameters=[
+                        {
+                            "vertical_bins": LaunchConfiguration("vertical_bins"),
+                            "min_azimuth_deg": LaunchConfiguration("min_azimuth_deg"),
+                            "max_azimuth_deg": LaunchConfiguration("max_azimuth_deg"),
+                            "is_agnocast_publish_node": True,
+                        }
+                    ]
+                    + [load_composable_node_param(context, "dual_return_filter_param_file")],
+                    extra_arguments=[
+                        {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
+                    ],
+                )
             )
-        )
 
     return nodes
 
@@ -299,6 +303,11 @@ def make_cuda_preprocessor_nodes(context):
         vehicle_info["max_height_offset"],
     ]
 
+    voxel_outlier_filter_arg = LaunchConfiguration("polar_voxel_filter").perform(context)
+    use_voxel_outlier_filter = (voxel_outlier_filter_arg in ['cpu', 'cuda'])
+    enable_ring_outlier_fileter  = False if use_voxel_outlier_filter else True
+    output_topic = "pointcloud_before_sync" if enable_ring_outlier_fileter else "rectified/pointcloud_ex"
+
     return [
         ComposableNode(
             package="autoware_cuda_pointcloud_preprocessor",
@@ -308,6 +317,7 @@ def make_cuda_preprocessor_nodes(context):
                 preprocessor_parameters,
                 distortion_corrector_node_param,
                 ring_outlier_filter_node_param,
+                {'enable_ring_outlier_filter': enable_ring_outlier_fileter},
             ],
             remappings=[
                 ("~/input/pointcloud", "pointcloud_raw_ex"),
@@ -316,14 +326,60 @@ def make_cuda_preprocessor_nodes(context):
                     "/sensing/vehicle_velocity_converter/twist_with_covariance",
                 ),
                 ("~/input/imu", "/sensing/imu/imu_data"),
-                ("~/output/pointcloud", "pointcloud_before_sync"),
-                ("~/output/pointcloud/cuda", "pointcloud_before_sync/cuda"),
+                ("~/output/pointcloud", output_topic),
+                ("~/output/pointcloud/cuda", output_topic + "/cuda"),
             ],
             # The whole node can not set use_intra_process due to type negotiation internal topics
             # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )
     ]
 
+def make_polar_voxel_outlier_filter_node(context):
+    parameters = [
+        ParameterFile(
+            LaunchConfiguration("polar_voxel_outlier_filter_node_param_file").perform(context),
+            allow_substs=True,
+        ),
+    ]
+
+    remappings = [
+        ("pandar_points", "pointcloud_raw_ex"),
+    ]
+
+    filter_type = LaunchConfiguration("polar_voxel_filter").perform(context)
+
+    if filter_type == "cpu":
+        return [
+            ComposableNode(
+                package="autoware_pointcloud_preprocessor",
+                plugin="autoware::pointcloud_preprocessor::PolarVoxelOutlierFilterComponent",
+                name="polar_voxel_outlier_filter_CPU",
+                parameters=parameters,
+                remappings=[
+                    ('input', 'rectified/pointcloud_ex'),
+                    ('output', 'pointcloud_before_sync')
+                ],
+            )
+        ]
+    elif filter_type == "cuda":
+        # NOTE(manato): Since cuda_pointcloud_preprocessor outputs data in XYZIRC, which is incompatible
+        # with cuda_polar_voxel_outlier_filter as of 2025/Aug/06, we need to set `use_cuda_preprocessor:=false`
+        return [
+            ComposableNode(
+                package="autoware_cuda_pointcloud_preprocessor",
+                plugin="autoware::cuda_pointcloud_preprocessor::CudaPolarVoxelOutlierFilterNode",
+                name="polar_voxel_outlier_filter_CUDA",
+                parameters=parameters,
+                remappings=[
+                    ("~/input/pointcloud", "rectified/pointcloud_ex"),
+                    ("~/input/pointcloud/cuda", "rectified/pointcloud_ex/cuda"),
+                    ("~/output/pointcloud", "pointcloud_before_sync"),
+                    ("~/output/pointcloud/cuda", "pointcloud_before_sync/cuda"),
+                ],
+            )
+        ]
+    else:
+        return []
 
 def make_blockage_diag_nodes(context):
     return [
@@ -388,6 +444,8 @@ def launch_setup(context, *args, **kwargs):
     else:
         nodes.extend(make_preprocessor_nodes(context))
         nodes.append(make_nebula_node(context, True))
+
+    nodes.extend(make_polar_voxel_outlier_filter_node(context))
 
     if IfCondition(LaunchConfiguration("enable_blockage_diag")).evaluate(context):
         nodes.extend(make_blockage_diag_nodes(context))
@@ -513,6 +571,15 @@ def generate_launch_description():
     add_launch_arg("point_filters.downsample_mask.path", "")
     add_launch_arg("hires_mode", "true")
     add_launch_arg("diagnostics.packet_loss.error_threshold")
+
+    add_launch_arg("polar_voxel_filter", "disable")  # "disable", "cpu", or "cuda"
+    add_launch_arg(
+        "polar_voxel_outlier_filter_node_param_file",
+        [
+            FindPackageShare("aip_common_sensor_launch"),
+            "/config/polar_voxel_outlier_filter_node.param.yaml",
+        ],
+    )
 
     set_container_executable = SetLaunchConfiguration(
         "container_executable",

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -218,7 +218,7 @@ def make_preprocessor_nodes(context):
     )
 
     voxel_outlier_filter_arg = LaunchConfiguration("polar_voxel_filter").perform(context)
-    use_voxel_outlier_filter = (voxel_outlier_filter_arg in ['cpu', 'cuda'])
+    use_voxel_outlier_filter = voxel_outlier_filter_arg in ["cpu", "cuda"]
 
     if not use_voxel_outlier_filter:
         if not use_dual_return_filter:
@@ -304,9 +304,11 @@ def make_cuda_preprocessor_nodes(context):
     ]
 
     voxel_outlier_filter_arg = LaunchConfiguration("polar_voxel_filter").perform(context)
-    use_voxel_outlier_filter = (voxel_outlier_filter_arg in ['cpu', 'cuda'])
-    enable_ring_outlier_fileter  = False if use_voxel_outlier_filter else True
-    output_topic = "pointcloud_before_sync" if enable_ring_outlier_fileter else "rectified/pointcloud_ex"
+    use_voxel_outlier_filter = voxel_outlier_filter_arg in ["cpu", "cuda"]
+    enable_ring_outlier_fileter = False if use_voxel_outlier_filter else True
+    output_topic = (
+        "pointcloud_before_sync" if enable_ring_outlier_fileter else "rectified/pointcloud_ex"
+    )
 
     return [
         ComposableNode(
@@ -317,7 +319,7 @@ def make_cuda_preprocessor_nodes(context):
                 preprocessor_parameters,
                 distortion_corrector_node_param,
                 ring_outlier_filter_node_param,
-                {'enable_ring_outlier_filter': enable_ring_outlier_fileter},
+                {"enable_ring_outlier_filter": enable_ring_outlier_fileter},
             ],
             remappings=[
                 ("~/input/pointcloud", "pointcloud_raw_ex"),
@@ -333,6 +335,7 @@ def make_cuda_preprocessor_nodes(context):
             # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )
     ]
+
 
 def make_polar_voxel_outlier_filter_node(context):
     parameters = [
@@ -356,8 +359,8 @@ def make_polar_voxel_outlier_filter_node(context):
                 name="polar_voxel_outlier_filter_CPU",
                 parameters=parameters,
                 remappings=[
-                    ('input', 'rectified/pointcloud_ex'),
-                    ('output', 'pointcloud_before_sync')
+                    ("input", "rectified/pointcloud_ex"),
+                    ("output", "pointcloud_before_sync"),
                 ],
             )
         ]
@@ -380,6 +383,7 @@ def make_polar_voxel_outlier_filter_node(context):
         ]
     else:
         return []
+
 
 def make_blockage_diag_nodes(context):
     return [


### PR DESCRIPTION
# Description
This PR adds support for launching `(cuda_)polar_voxel_outlier_filter`. 

**Note:**  Since cuda_pointcloud_preprocessor outputs data in `XYZIRC` format, which is incompatible with cuda_polar_voxel_outlier_filter as of 2025/Aug/06, we need to set `use_cuda_preprocessor:=false` to enable cuda_polar_voxel_outlier_filter. (or use the CPU version polar_voxel_outlier_filter (by specifying `polar_voxel_filter:=cpu`) to work with cuda_pointcloud_preprocessor)