### PR TITLE
fix(aip_x2_gen2_launch): add missing cuda-related args to rear_upper LiDAR launch

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -10,8 +10,8 @@
   <arg name="vehicle_mirror_param_file"/>
   <arg name="use_pointcloud_container" default="false" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
-  <arg name="use_shared_container" default="false"/>
-  <arg name="use_cuda_preprocessor" default="false"/>
+  <arg name="use_shared_container" default="true"/>
+  <arg name="use_cuda_preprocessor" default="true"/>
   <arg name="udp_only" default="false"/>
   <arg name="dual_return_filter_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/dual_return_filter.param.yaml"/>
   <arg name="ring_outlier_filter_node_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/ring_outlier_filter_node.param.yaml"/>
@@ -51,6 +51,8 @@
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
+        <arg name="use_shared_container" value="$(var use_shared_container)"/>
+        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
         <arg name="blockage_range" value="[105.0, 270.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="40" />


### PR DESCRIPTION
```xml
        <arg name="use_shared_container" value="$(var use_shared_container)"/>
        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
```

were missing.

Tested on bench on 2025/08/14.