### PR TITLE
fix: dummy camera diag

### DIFF
--- a/aip_x2_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -72,14 +72,8 @@
       "tier4_camera_sync_doctor7: camera7_sync_status": default
 
       # /sensing/camera/004-image
-      "v4l2_camera_camera0: image_diagnostics": default
-      "v4l2_camera_camera1: image_diagnostics": default
-      "v4l2_camera_camera2: image_diagnostics": default
-      "v4l2_camera_camera3: image_diagnostics": default
-      "v4l2_camera_camera4: image_diagnostics": default
-      "v4l2_camera_camera5: image_diagnostics": default
-      "v4l2_camera_camera6: image_diagnostics": default
-      "v4l2_camera_camera7: image_diagnostics": default
+      "image_diagnostics3: camera3": default
+      "image_diagnostics5: camera5": default
 
       # /sensing/camera/006-hw-diag
       "uevent_diagnostics_publisher_0: camera0_uevent_diag": default


### PR DESCRIPTION
diag pathが間違っていたためdummy diagも修正 ([slack](https://star4.slack.com/archives/C07K9RBUQR3/p1755243949272099?thread_ts=1755239932.687139&cid=C07K9RBUQR3)) 