### PR TITLE
feat(autoware_pointcloud_preprocessor): output concatenation info

### DIFF
--- a/aip_x1_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x1_launch/launch/pointcloud_preprocessor.launch.py
@@ -43,6 +43,7 @@ def launch_setup(context, *args, **kwargs):
         remappings=[
             ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
             ("output", "concatenated/pointcloud"),
+            ("output_info", "concatenated/pointcloud_info"),
         ],
         parameters=[concatenate_and_time_sync_node_param],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],

--- a/aip_x2_gen2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x2_gen2_launch/launch/pointcloud_preprocessor.launch.py
@@ -40,6 +40,7 @@ def launch_setup(context, *args, **kwargs):
     concat_remappings = [
         ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
         ("output", "concatenated/pointcloud"),
+        ("output_info", "concatenated/pointcloud_info"),
     ]
     concat_extra_arguments = []
 

--- a/aip_x2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x2_launch/launch/pointcloud_preprocessor.launch.py
@@ -44,6 +44,7 @@ def launch_setup(context, *args, **kwargs):
         remappings=[
             ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
             ("output", "concatenated/pointcloud"),
+            ("output_info", "concatenated/pointcloud_info"),
         ],
         parameters=[concatenate_and_time_sync_node_param],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],

--- a/aip_xx1_gen2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_xx1_gen2_launch/launch/pointcloud_preprocessor.launch.py
@@ -44,6 +44,7 @@ def launch_setup(context, *args, **kwargs):
         remappings=[
             ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
             ("output", "concatenated/pointcloud"),
+            ("output_info", "concatenated/pointcloud_info"),
         ],
         parameters=[concatenate_and_time_sync_node_param],
         extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],

--- a/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_xx1_launch/launch/pointcloud_preprocessor.launch.py
@@ -40,6 +40,7 @@ def launch_setup(context, *args, **kwargs):
     concat_remappings = [
         ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
         ("output", "concatenated/pointcloud"),
+        ("output_info", "concatenated/pointcloud_info"),
     ]
     concat_extra_arguments = []
 


### PR DESCRIPTION
By using autoware_msgs 1.10.0, we can publish concatenation info directly for downstream modules, improving performance.