### PR TITLE
chore(x2gen2): better CUDA pipeline

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -10,12 +10,18 @@
   <arg name="vehicle_mirror_param_file"/>
   <arg name="use_pointcloud_container" default="false" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
-  <arg name="use_shared_container" default="true"/>
-  <arg name="use_cuda_preprocessor" default="true"/>
+  <arg name="pipeline_mode" default="cuda">
+    <choice value="cuda"/>
+    <choice value="cpu"/>
+    <choice value="cuda-all-in-one"/>
+    <choice value="cuda-with-cpu-concat"/>
+  </arg>
   <arg name="udp_only" default="false"/>
   <arg name="dual_return_filter_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/dual_return_filter.param.yaml"/>
   <arg name="ring_outlier_filter_node_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/ring_outlier_filter_node.param.yaml"/>
   <arg name="enable_blockage_diag" default="true"/>
+
+  <let name="use_cuda_concat" value="$(eval pipeline_mode in ['cuda', 'cuda-all-in-one'])"/>
 
   <group>
     <push-ros-namespace namespace="lidar" />
@@ -24,8 +30,7 @@
       <arg name="base_frame" value="base_link" />
       <arg name="use_intra_process" value="true" />
       <arg name="use_multithread" value="true" />
-      <arg name="use_pointcloud_container" value="true"/>
-      <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+      <arg name="use_cuda" value="$(var use_cuda_concat)"/>
       <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
     </include>
 
@@ -51,8 +56,7 @@
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="use_shared_container" value="$(var use_shared_container)"/>
-        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+        <arg name="pipeline_mode" value="$(var pipeline_mode)"/>
         <arg name="blockage_range" value="[105.0, 270.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="40" />
@@ -94,8 +98,7 @@
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="use_shared_container" value="$(var use_shared_container)"/>
-        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+        <arg name="pipeline_mode" value="$(var pipeline_mode)"/>
         <arg name="blockage_range" value="[90.0, 270.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="40" />
@@ -137,8 +140,7 @@
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="use_shared_container" value="$(var use_shared_container)"/>
-        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+        <arg name="pipeline_mode" value="$(var pipeline_mode)"/>
         <arg name="blockage_range" value="[130.0, 230.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="118" />
@@ -179,8 +181,7 @@
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="use_shared_container" value="$(var use_shared_container)"/>
-        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+        <arg name="pipeline_mode" value="$(var pipeline_mode)"/>
         <arg name="blockage_range" value="[140.0, 230.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="118" />
@@ -222,8 +223,7 @@
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="use_shared_container" value="$(var use_shared_container)"/>
-        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+        <arg name="pipeline_mode" value="$(var pipeline_mode)"/>
         <arg name="blockage_range" value="[90.0, 270.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="40" />
@@ -265,8 +265,7 @@
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="use_shared_container" value="$(var use_shared_container)"/>
-        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+        <arg name="pipeline_mode" value="$(var pipeline_mode)"/>
         <arg name="blockage_range" value="[90.0, 270.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="40" />
@@ -308,8 +307,7 @@
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="use_shared_container" value="$(var use_shared_container)"/>
-        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+        <arg name="pipeline_mode" value="$(var pipeline_mode)"/>
         <arg name="blockage_range" value="[130.0, 230.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="118" />
@@ -350,8 +348,7 @@
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>
         <arg name="container_name" value="$(var pointcloud_container_name)"/>
-        <arg name="use_shared_container" value="$(var use_shared_container)"/>
-        <arg name="use_cuda_preprocessor" value="$(var use_cuda_preprocessor)"/>
+        <arg name="pipeline_mode" value="$(var pipeline_mode)"/>
         <arg name="blockage_range" value="[150.0, 220.0]"/>
         <arg name="vertical_bins" value ="128" />
         <arg name="horizontal_ring_id" value="118" />

--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -21,7 +21,7 @@
   <arg name="ring_outlier_filter_node_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/ring_outlier_filter_node.param.yaml"/>
   <arg name="enable_blockage_diag" default="true"/>
 
-  <let name="use_cuda_concat" value="$(eval pipeline_mode in ['cuda', 'cuda-all-in-one'])"/>
+  <let name="use_cuda_concat" value="$(eval '\'$(var pipeline_mode)\' == \'cuda\' or \'$(var pipeline_mode)\' == \'cuda-all-in-one\'')"/>
 
   <group>
     <push-ros-namespace namespace="lidar" />

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -417,6 +417,14 @@ def generate_launch_description():
             DeclareLaunchArgument(name, default_value=default_value, description=description)
         )
 
+    # Agnocast parameters
+    add_launch_arg(
+        "agnocast_heaphook_path",
+        "/opt/ros/humble/lib/libagnocast_heaphook.so",
+        "Path to the agnocast heaphook library",
+    )
+
+    # Nebula parameters
     add_launch_arg("sensor_model", description="sensor model name")
     add_launch_arg(
         "nebula_common_config_file",
@@ -427,13 +435,8 @@ def generate_launch_description():
         description="file containing parameters common to all Nebula instances",
     )
     add_launch_arg("config_file", "", description="sensor configuration file")
-    add_launch_arg(
-        "agnocast_heaphook_path",
-        "/opt/ros/humble/lib/libagnocast_heaphook.so",
-        "Path to the agnocast heaphook library",
-    )
-    add_launch_arg("launch_hw", "True", "do launch driver")
-    add_launch_arg("setup_sensor", "True", "configure sensor")
+    add_launch_arg("launch_hw", "true", "do launch driver")
+    add_launch_arg("setup_sensor", "true", "configure sensor")
     add_launch_arg("sensor_ip", "192.168.1.201", "device ip address")
     add_launch_arg(
         "multicast_ip",
@@ -455,11 +458,11 @@ def generate_launch_description():
     add_launch_arg("rotation_speed", "600", "rotational frequency")
     add_launch_arg("dual_return_distance_threshold", "0.1", "dual return distance threshold")
     add_launch_arg("frame_id", "lidar", "frame id")
+    add_launch_arg("diag_span", "1000")
     add_launch_arg("input_frame", LaunchConfiguration("base_frame"), "use for cropbox")
     add_launch_arg("output_frame", LaunchConfiguration("base_frame"), "use for cropbox")
-    add_launch_arg("diag_span", "1000")
-    add_launch_arg("use_multithread", "False", "use multithread")
-    add_launch_arg("use_intra_process", "False", "use ROS 2 component container communication")
+    add_launch_arg("use_multithread", "true", "use multithread")
+    add_launch_arg("use_intra_process", "true", "use intra-process communication in containers")
     add_launch_arg("container_name", "pointcloud_container")
     add_launch_arg(
         "use_shared_container",
@@ -503,7 +506,7 @@ def generate_launch_description():
     add_launch_arg("enable_blockage_diag", "true")
 
     add_launch_arg("calibration_file", "")
-    add_launch_arg("output_as_sensor_frame", "True", "output final pointcloud in sensor frame")
+    add_launch_arg("output_as_sensor_frame", "true", "output final pointcloud in sensor frame")
     add_launch_arg("use_dual_return_filter", "false")
     add_launch_arg("point_filters.downsample_mask.path", "")
     add_launch_arg("hires_mode", "true")

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -74,16 +74,13 @@ def create_parameter_dict(*args):
 
 
 def make_common_nodes(context):
-    if UnlessCondition(LaunchConfiguration("use_shared_container")).evaluate(context):
-        return [
-            ComposableNode(
-                package="autoware_glog_component",
-                plugin="autoware::glog_component::GlogComponent",
-                name="glog_component",
-            )
-        ]
-
-    return []
+    return [
+        ComposableNode(
+            package="autoware_glog_component",
+            plugin="autoware::glog_component::GlogComponent",
+            name="glog_component",
+        )
+    ]
 
 
 def make_nebula_node(context, as_composable_node, env=None):
@@ -392,7 +389,7 @@ def launch_setup(context, *args, **kwargs):
             if use_blockage_diag:
                 shared_container_nodes.extend(make_blockage_diag_nodes(context))
         case "cpu":
-            lidar_specific_container_nodes.append(make_preprocessor_nodes(context))
+            lidar_specific_container_nodes.extend(make_preprocessor_nodes(context))
             lidar_specific_container_nodes.append(make_nebula_node(context, True))
 
             if use_blockage_diag:
@@ -409,6 +406,7 @@ def launch_setup(context, *args, **kwargs):
     launch_targets = []
 
     if lidar_specific_container_nodes:
+        lidar_specific_container_nodes.extend(make_common_nodes(context))
         lidar_specific_container = ComposableNodeContainer(
             name=LaunchConfiguration("container_name"),
             namespace="pointcloud_preprocessor",
@@ -424,11 +422,10 @@ def launch_setup(context, *args, **kwargs):
         load_shared_container_nodes = LoadComposableNodes(
             composable_node_descriptions=shared_container_nodes,
             target_container=LaunchConfiguration("container_name"),
-            condition=IfCondition(LaunchConfiguration("use_shared_container")),
         )
         launch_targets.append(load_shared_container_nodes)
 
-    launch_targets.append(standalone_nodes)
+    launch_targets.extend(standalone_nodes)
 
     return launch_targets
 

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -364,11 +364,6 @@ def make_agnocast_env(context):
 
 
 def launch_setup(context, *args, **kwargs):
-    def str2vector(string):
-        return [float(x) for x in string.strip("[]").split(",")]
-
-    # Start
-
     # Check that the cuda preprocessor is only used with a shared container
     if IfCondition(LaunchConfiguration("use_cuda_preprocessor")).evaluate(context):
         assert IfCondition(LaunchConfiguration("use_shared_container")).evaluate(

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -551,7 +551,4 @@ def generate_launch_description():
     add_launch_arg("hires_mode", "true")
     add_launch_arg("diagnostics.packet_loss.error_threshold")
 
-    return launch.LaunchDescription(
-        launch_arguments
-        + [OpaqueFunction(function=launch_setup)]
-    )
+    return launch.LaunchDescription(launch_arguments + [OpaqueFunction(function=launch_setup)])

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 
 import launch
@@ -30,6 +31,8 @@ from launch_ros.descriptions import ComposableNode
 from launch_ros.parameter_descriptions import ParameterFile
 from launch_ros.substitutions import FindPackageShare
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 def get_lidar_make(sensor_name):
@@ -353,59 +356,81 @@ def make_blockage_diag_nodes(context):
 
 def make_agnocast_env(context):
     agnocast_heaphook_path = LaunchConfiguration("agnocast_heaphook_path").perform(context)
-
-    if os.getenv("ENABLE_AGNOCAST") == "1":
-        return {
-            "LD_PRELOAD": f"{agnocast_heaphook_path}:{os.getenv('LD_PRELOAD', '')}",  # noqa: E231
-            "AGNOCAST_MEMPOOL_SIZE": "1073741824",  # 1GB
-        }
-
-    return {}
+    return {
+        "LD_PRELOAD": f"{agnocast_heaphook_path}:{os.getenv('LD_PRELOAD', '')}",  # noqa: E231
+        "AGNOCAST_MEMPOOL_SIZE": "1073741824",  # 1GB
+    }
 
 
 def launch_setup(context, *args, **kwargs):
-    # Check that the cuda preprocessor is only used with a shared container
-    if IfCondition(LaunchConfiguration("use_cuda_preprocessor")).evaluate(context):
-        assert IfCondition(LaunchConfiguration("use_shared_container")).evaluate(
-            context
-        ), "The cuda preprocessor should only be used with a shared container."
+    mode = LaunchConfiguration("pipeline_mode").perform(context)
+    use_agnocast = os.getenv("ENABLE_AGNOCAST") == "1"
+    env = make_agnocast_env(context) if use_agnocast else {}
 
-    env = make_agnocast_env(context)
+    use_blockage_diag = IfCondition(LaunchConfiguration("enable_blockage_diag")).evaluate(context)
 
-    nodes = []
+    shared_container_nodes = []
+    lidar_specific_container_nodes = []
     standalone_nodes = []
 
-    nodes.extend(make_common_nodes(context))
+    match mode:
+        case "cuda":
+            if not use_agnocast:
+                logger.warning("This pipeline mode may perform better when using Agnocast")
 
-    if IfCondition(LaunchConfiguration("use_cuda_preprocessor")).evaluate(context):
-        nodes.extend(make_cuda_preprocessor_nodes(context))
-        standalone_nodes.append(make_nebula_node(context, False, env))
-    else:
-        nodes.extend(make_preprocessor_nodes(context))
-        nodes.append(make_nebula_node(context, True))
+            shared_container_nodes.extend(make_cuda_preprocessor_nodes(context))
 
-    if IfCondition(LaunchConfiguration("enable_blockage_diag")).evaluate(context):
-        nodes.extend(make_blockage_diag_nodes(context))
+            if use_blockage_diag:
+                lidar_specific_container_nodes.append(make_nebula_node(context, True))
+                lidar_specific_container_nodes.extend(make_blockage_diag_nodes(context))
+            else:
+                standalone_nodes.append(make_nebula_node(context, False, env))
+        case "cuda-all-in-one":
+            shared_container_nodes.extend(make_cuda_preprocessor_nodes(context))
+            shared_container_nodes.append(make_nebula_node(context, True))
 
-    # set container to run all required components in the same process
-    container = ComposableNodeContainer(
-        name=LaunchConfiguration("container_name"),
-        namespace="pointcloud_preprocessor",
-        package="rclcpp_components",
-        executable=LaunchConfiguration("container_executable"),
-        composable_node_descriptions=nodes,
-        output="both",
-        condition=UnlessCondition(LaunchConfiguration("use_shared_container")),
-        additional_env=env,
-    )
+            if use_blockage_diag:
+                shared_container_nodes.extend(make_blockage_diag_nodes(context))
+        case "cpu":
+            lidar_specific_container_nodes.append(make_preprocessor_nodes(context))
+            lidar_specific_container_nodes.append(make_nebula_node(context, True))
 
-    load_composable_nodes = LoadComposableNodes(
-        composable_node_descriptions=nodes,
-        target_container=LaunchConfiguration("container_name"),
-        condition=IfCondition(LaunchConfiguration("use_shared_container")),
-    )
+            if use_blockage_diag:
+                lidar_specific_container_nodes.extend(make_blockage_diag_nodes(context))
+        case "cuda-with-cpu-concat":
+            lidar_specific_container_nodes.extend(make_cuda_preprocessor_nodes(context))
+            lidar_specific_container_nodes.append(make_nebula_node(context, True))
 
-    return [container, load_composable_nodes] + standalone_nodes
+            if use_blockage_diag:
+                lidar_specific_container_nodes.extend(make_blockage_diag_nodes(context))
+        case _:
+            raise ValueError(f"Unknown pipeline mode: {mode}")
+
+    launch_targets = []
+
+    if lidar_specific_container_nodes:
+        lidar_specific_container = ComposableNodeContainer(
+            name=LaunchConfiguration("container_name"),
+            namespace="pointcloud_preprocessor",
+            package="rclcpp_components",
+            executable=LaunchConfiguration("container_executable"),
+            composable_node_descriptions=lidar_specific_container_nodes,
+            output="both",
+            additional_env=env,
+        )
+        launch_targets.append(lidar_specific_container)
+
+    if shared_container_nodes:
+        load_shared_container_nodes = LoadComposableNodes(
+            composable_node_descriptions=shared_container_nodes,
+            target_container=LaunchConfiguration("container_name"),
+            condition=IfCondition(LaunchConfiguration("use_shared_container")),
+        )
+        launch_targets.append(load_shared_container_nodes)
+
+    launch_targets.append(standalone_nodes)
+
+    return launch_targets
 
 
 def generate_launch_description():
@@ -467,14 +492,10 @@ def generate_launch_description():
     add_launch_arg("use_intra_process", "true", "use intra-process communication in containers")
     add_launch_arg("container_name", "pointcloud_container")
     add_launch_arg(
-        "use_shared_container",
-        "False",
-        "Whether to use a new container for this lidar or use an existing one",
-    )
-    add_launch_arg(
-        "use_cuda_preprocessor",
-        "False",
-        "Use the cuda implementation of the pointcloud preprocessor. Requires use_shared_container to be enabled",
+        "pipeline_mode",
+        "cuda",
+        "Which pointcloud preprocessor pipeline mode to use",
+        choices=["cuda", "cpu", "cuda-all-in-one", "cuda-with-cpu-concat"],
     )
 
     add_launch_arg("dual_return_filter_param_file")

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -370,6 +370,23 @@ def launch_setup(context, *args, **kwargs):
     lidar_specific_container_nodes = []
     standalone_nodes = []
 
+    container_exec = "agnocast_component_container" if use_agnocast else "component_container"
+    container_exec_mt = (
+        "agnocast_component_container_mt" if use_agnocast else "component_container_mt"
+    )
+
+    set_container_executable = SetLaunchConfiguration(
+        "container_executable",
+        container_exec,
+        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
+    )
+
+    set_container_mt_executable = SetLaunchConfiguration(
+        "container_executable",
+        container_exec_mt,
+        condition=IfCondition(LaunchConfiguration("use_multithread")),
+    )
+
     match mode:
         case "cuda":
             if not use_agnocast:
@@ -403,14 +420,16 @@ def launch_setup(context, *args, **kwargs):
         case _:
             raise ValueError(f"Unknown pipeline mode: {mode}")
 
-    launch_targets = []
+    launch_targets = [set_container_executable, set_container_mt_executable]
 
     if lidar_specific_container_nodes:
+        container_package = "agnocastlib" if use_agnocast else "rclcpp_components"
+
         lidar_specific_container_nodes.extend(make_common_nodes(context))
         lidar_specific_container = ComposableNodeContainer(
             name=LaunchConfiguration("container_name"),
             namespace="pointcloud_preprocessor",
-            package="rclcpp_components",
+            package=container_package,
             executable=LaunchConfiguration("container_executable"),
             composable_node_descriptions=lidar_specific_container_nodes,
             output="both",
@@ -532,20 +551,7 @@ def generate_launch_description():
     add_launch_arg("hires_mode", "true")
     add_launch_arg("diagnostics.packet_loss.error_threshold")
 
-    set_container_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container",
-        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
-    )
-
-    set_container_mt_executable = SetLaunchConfiguration(
-        "container_executable",
-        "component_container_mt",
-        condition=IfCondition(LaunchConfiguration("use_multithread")),
-    )
-
     return launch.LaunchDescription(
         launch_arguments
-        + [set_container_executable, set_container_mt_executable]
         + [OpaqueFunction(function=launch_setup)]
     )

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -411,10 +411,12 @@ def launch_setup(context, *args, **kwargs):
 def generate_launch_description():
     launch_arguments = []
 
-    def add_launch_arg(name: str, default_value=None, description=None):
+    def add_launch_arg(name: str, default_value=None, description=None, **kwargs):
         # a default_value of None is equivalent to not passing that kwarg at all
         launch_arguments.append(
-            DeclareLaunchArgument(name, default_value=default_value, description=description)
+            DeclareLaunchArgument(
+                name, default_value=default_value, description=description, **kwargs
+            )
         )
 
     # Agnocast parameters

--- a/aip_x2_gen2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x2_gen2_launch/launch/pointcloud_preprocessor.launch.py
@@ -85,9 +85,9 @@ def generate_launch_description():
 
     aip_x2_gen2_launch_share_dir = get_package_share_directory("aip_x2_gen2_launch")
 
-    add_launch_arg("use_multithread", "True")
-    add_launch_arg("use_intra_process", "True")
-    add_launch_arg("use_cuda_preprocessor", "False")
+    add_launch_arg("use_multithread", "true")
+    add_launch_arg("use_intra_process", "true")
+    add_launch_arg("use_cuda", "false")
     add_launch_arg("pointcloud_container_name", "pointcloud_container")
     add_launch_arg(
         "concatenate_and_time_sync_node_param_path",

--- a/aip_x2_gen2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_x2_gen2_launch/launch/pointcloud_preprocessor.launch.py
@@ -43,7 +43,7 @@ def launch_setup(context, *args, **kwargs):
     ]
     concat_extra_arguments = []
 
-    if IfCondition(LaunchConfiguration("use_cuda_preprocessor")).evaluate(context):
+    if IfCondition(LaunchConfiguration("use_cuda")).evaluate(context):
         concat_package = "autoware_cuda_pointcloud_preprocessor"
         concat_plugin = "autoware::cuda_pointcloud_preprocessor::CudaPointCloudConcatenateDataSynchronizerComponent"
         # NOTE(knzo25): when using  the cuda blackboard, this setting can not be made global


### PR DESCRIPTION
This PR 
* fixes the performance issues of the CUDA pointcloud preprocessor pipeline
* refactors the LiDAR launch structure to make clear which modes are officially supported

The CUDA pointlcoud preprocessor pipeline is still set as the default.

## Pipeline Changes

The parameters `use_shared_container` and `use_cuda_preprocessor` have been replaced by a parameter `pipeline_mode` in `aip_x2_gen2_launch/launch/lidar.xml` to ensure that a valid and tested configuration is launched.

There was an issue where Nebula pointclouds were sent to `blockage_diag` via DDS, since the two nodes were in two different containers when using the CUDA pointcloud preprocessor pipeline. This has been resolved in the new `cuda` pipeline mode.

### Old Structure

#### `use_shared_container:=true use_cuda_preprocessor:=true`

```mermaid
graph LR
    nebula["nebula (8x)"]

    subgraph pointcloud_container
        blockage_diag["blockage_diag (8x)"]
        cuda_preprocessor["cuda_preprocessor (8x)"] -->|cuda_blackboard| cuda_concat
        cuda_concat -->|cuda_blackboard| ...
    end

    nebula -->|agnocast| cuda_preprocessor
    nebula -->|dds| blockage_diag
```

### New Structure

#### `pipeline_mode:=cuda`

```mermaid
graph LR
    subgraph nebula_container ["nebula_container (8x)"]
        nebula
        nebula -->|intra_process| blockage_diag
    end

    subgraph pointcloud_container
        cuda_preprocessor["cuda_preprocessor (8x)"] -->|cuda_blackboard| cuda_concat
        cuda_concat -->|cuda_blackboard| ...
    end

    nebula -->|agnocast| cuda_preprocessor
```

#### `pipeline_mode:=cpu`

```mermaid
graph LR
    subgraph nebula_container ["nebula_container (8x)"]
        nebula
        nebula -->|intra_process| cpu_preprocessor["cpu_preprocessor"]
    end

    subgraph pointcloud_container
        cpu_preprocessor -->|dds| cpu_concat
        cpu_concat -->|intra_process| ...
    end
```

#### `pipeline_mode:=cuda-all-in-one`

```mermaid
graph TD
    subgraph pointcloud_container
        nebula["nebula (8x)"] -->|intra_process| blockage_diag["blockage_diag (8x)"]
        cuda_preprocessor["cuda_preprocessor (8x)"] -->|cuda_blackboard| cuda_concat
        cuda_concat -->|cuda_blackboard| ...
        nebula -->|intra_process| cuda_preprocessor
    end
```

#### `pipeline_mode:=cuda-with-cpu-concat`

```mermaid
graph LR
    subgraph nebula_container ["nebula_container (8x)"]
        nebula -->|intra_process| blockage_diag
        nebula -->|intra_process| gpu_preprocessor["gpu_preprocessor"]
    end

    subgraph pointcloud_container
        gpu_preprocessor -->|dds| cpu_concat
        cpu_concat -->|intra_process| ...
    end
```

## Performance

### Overall Rating

| `pipeline_mode` | `lo` peak traffic | Comment |
|--|--:|--|
| `cpu` | 1.92 Gb | As Agnocast support for CPU preprocessor is not ported from `v4.2` to `v4.3`, this performs worst. |
| `cuda-all-in-one` | 1.33 Gb | Performs best in all metrics. |
| `cuda-with-cpu-concat` | 1.64 Gb | The approach used in XX1. Since DDS is used for publishing clouds to concat, and X2gen2 has 8 LiDARs, this performs worse than on XX1. |
| `cuda` | 1.39 Gb | Performs almost as well as `cuda-all-in-one`. Provides fault isolation if one LiDAR/Nebula instance crashes |

### Benchmarks using Live Bench LiDARs

<img width="1582" height="927" alt="bench" src="https://github.com/user-attachments/assets/6400dc66-6133-42cb-82a5-211d200ff572" />

### Benchmarks using a Shiojiri Rosbag

> [!NOTE]
> The CPU preprocessor experienced extreme packet loss when replaying a rosbag. Either CPU resources had been used up, or `lo` bandwidth was saturated. Due to the lost packets, GPU & CPU usage are lower since the pipeline starved.

<img width="1582" height="927" alt="rosbag" src="https://github.com/user-attachments/assets/6182ebe2-3419-492f-90ee-5f289c473db0" />
