### PR TITLE
chore: use_twist_compenstation=false

### DIFF
--- a/aip_common_sensor_launch/config/radar_tracks_msgs_converter.param.yaml
+++ b/aip_common_sensor_launch/config/radar_tracks_msgs_converter.param.yaml
@@ -2,6 +2,6 @@
   ros__parameters:
     update_rate_hz: 20.0
     new_frame_id: "base_link"
-    use_twist_compensation: true
+    use_twist_compensation: false
     use_twist_yaw_compensation: false
     static_object_speed_threshold: 1.0


### PR DESCRIPTION
Following https://github.com/tier4/aip_launcher/pull/410

This feature is updated in X2 Gen2, and XX1 Gen2 has no reason not to align with that update.

After this update, X2 can also use the common configuration file.
