### PR TITLE
feat: throttle radar input topics

### DIFF
--- a/aip_xx1_gen2_launch/config/ARS548.param.yaml
+++ b/aip_xx1_gen2_launch/config/ARS548.param.yaml
@@ -10,10 +10,10 @@
     sensor_model: ARS548
     configuration_host_port: 42401
     configuration_sensor_port: 42101
-    use_sensor_time: false
+    use_sensor_time: true
     radar_info_rate_subsample: 10
-    configuration_vehicle_length: 4.4 #  0.8 + 2.75 + 0.85
-    configuration_vehicle_width: 1.695 # 1.485 + 0.105 + 0.105
+    configuration_vehicle_length: 4.4 #  0.8 + 2.75 + 0.85 # wheel_base + front_overhang + rear_overhang
+    configuration_vehicle_width: 1.695 # 1.485 + 0.105 + 0.105  # wheel_tread + left_overhang + right_overhang
     configuration_vehicle_height: 2.5
     configuration_vehicle_wheelbase: 2.75
     diagnostics:

--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -25,12 +25,19 @@
   </group>
 
   <group if="$(eval &quot;'$(var ars_version)'=='ars548'&quot;)">
-    <let name="odometry_topic" value="/localization/kinematic_state"/>
-    <let name="twist_topic" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
+    <let name="odometry_topic" value="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
     <let name="acceleration_topic" value="/localization/acceleration"/>
     <let name="steering_angle_topic" value="/vehicle/status/steering_status_scalar"/>
     <arg name="radar_tracks_msgs_converter_param_path" default="$(find-pkg-share aip_common_sensor_launch)/config/radar_tracks_msgs_converter.param.yaml"/>
     <push-ros-namespace namespace="radar"/>
+
+    <let name="odometry_throttled_topic" value="$(var odometry_topic)_throttled"/>
+    <let name="acceleration_throttled_topic" value="$(var acceleration_topic)_throttled"/>
+    <let name="steering_angle_throttled_topic" value="$(var steering_angle_topic)_throttled"/>
+
+    <node pkg="topic_tools" exec="throttle" name="odometry_throttler" output="screen" args="messages $(var odometry_topic) 25.0 $(var odometry_throttled_topic)"/>
+    <node pkg="topic_tools" exec="throttle" name="acceleration_throttler" output="screen" args="messages $(var acceleration_topic) 25.0 $(var acceleration_throttled_topic)"/>
+    <node pkg="topic_tools" exec="throttle" name="steering_angle_throttler" output="screen" args="messages $(var steering_angle_topic) 25.0 $(var steering_angle_throttled_topic)"/>
 
     <node pkg="topic_tools" exec="transform" name="steer_angle_transform" output="screen" args="/vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float32 'std_msgs.msg.Float32(data=m.steering_tire_angle)'  --import autoware_vehicle_msgs std_msgs --wait-for-start"/>
     <!-- ros2 run topic_tools transform /vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float64 'std_msgs.msg.Float64(data=m.steering_tire_angle)'  \-\-import autoware_auto_vehicle_msgs std_msgs -->
@@ -40,9 +47,9 @@
       <group>
         <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/ars548.launch.xml">
           <!-- in  -->
-          <arg name="odometry_topic" value="$(var twist_topic)"/>
-          <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
-          <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+          <arg name="odometry_topic" value="$(var odometry_throttled_topic)"/>
+          <arg name="acceleration_topic" value="$(var acceleration_throttled_topic)"/>
+          <arg name="steering_angle_topic" value="$(var steering_angle_throttled_topic)"/>
           <arg name="launch_hw" value="$(var launch_driver)"/>
 
           <arg name="sensor_ip" value="10.13.1.114"/>
@@ -73,9 +80,9 @@
       <group>
         <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/ars548.launch.xml">
 
-          <arg name="odometry_topic" value="$(var twist_topic)"/>
-          <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
-          <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+          <arg name="odometry_topic" value="$(var odometry_throttled_topic)"/>
+          <arg name="acceleration_topic" value="$(var acceleration_throttled_topic)"/>
+          <arg name="steering_angle_topic" value="$(var steering_angle_throttled_topic)"/>
           <arg name="launch_hw" value="$(var launch_driver)"/>
 
           <arg name="sensor_ip" value="10.13.1.115"/>
@@ -106,9 +113,9 @@
       <group>
         <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/ars548.launch.xml">
 
-          <arg name="odometry_topic" value="$(var twist_topic)"/>
-          <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
-          <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+          <arg name="odometry_topic" value="$(var odometry_throttled_topic)"/>
+          <arg name="acceleration_topic" value="$(var acceleration_throttled_topic)"/>
+          <arg name="steering_angle_topic" value="$(var steering_angle_throttled_topic)"/>
           <arg name="launch_hw" value="$(var launch_driver)"/>
 
           <arg name="sensor_ip" value="10.13.1.116"/>
@@ -139,9 +146,9 @@
       <group>
         <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/ars548.launch.xml">
 
-          <arg name="odometry_topic" value="$(var twist_topic)"/>
-          <arg name="acceleration_topic" value="$(var acceleration_topic)"/>
-          <arg name="steering_angle_topic" value="$(var steering_angle_topic)"/>
+          <arg name="odometry_topic" value="$(var odometry_throttled_topic)"/>
+          <arg name="acceleration_topic" value="$(var acceleration_throttled_topic)"/>
+          <arg name="steering_angle_topic" value="$(var steering_angle_throttled_topic)"/>
           <arg name="launch_hw" value="$(var launch_driver)"/>
 
           <arg name="sensor_ip" value="10.13.1.117"/>

--- a/aip_xx1_gen2_launch/launch/sensing.launch.xml
+++ b/aip_xx1_gen2_launch/launch/sensing.launch.xml
@@ -39,10 +39,10 @@
     </include>
 
     <!-- Radar Driver -->
-    <!-- <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/radar.launch.xml">
+    <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/radar.launch.xml">
       <arg name="launch_driver" value="$(var launch_driver)" />
       <arg name="ars_version" value="ars548" />
-    </include> -->
+    </include>
 
     <!-- Vehicle twist -->
     <include file="$(find-pkg-share autoware_vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">

--- a/aip_xx1_gen2_launch/launch/sensing.launch.xml
+++ b/aip_xx1_gen2_launch/launch/sensing.launch.xml
@@ -39,10 +39,10 @@
     </include>
 
     <!-- Radar Driver -->
-    <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/radar.launch.xml">
+    <!-- <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/radar.launch.xml">
       <arg name="launch_driver" value="$(var launch_driver)" />
       <arg name="ars_version" value="ars548" />
-    </include>
+    </include> -->
 
     <!-- Vehicle twist -->
     <include file="$(find-pkg-share autoware_vehicle_velocity_converter)/launch/vehicle_velocity_converter.launch.xml">


### PR DESCRIPTION

https://github.com/tier4/aip_launcher/pull/371

This update synchronize the updates from X2 to XX1.

- enable use_sensor_time
- throttle all input topics to 40Hz