### PR TITLE
chore: specially for v0.41, handle change in odometry variable name

### DIFF
--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -68,7 +68,7 @@
       <group>
         <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
           <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
+          <arg name="input/odometry" value="/localization/kinematic_state"/>
           <arg name="output/radar_detected_objects" value="detected_objects"/>
           <arg name="output/radar_tracked_objects" value="tracked_objects"/>
           <arg name="use_twist_compensation" value="false"/>
@@ -103,7 +103,7 @@
       <group>
         <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
           <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
+          <arg name="input/odometry" value="/localization/kinematic_state"/>
           <arg name="output/radar_detected_objects" value="detected_objects"/>
           <arg name="output/radar_tracked_objects" value="tracked_objects"/>
           <arg name="use_twist_compensation" value="false"/>
@@ -138,7 +138,7 @@
       <group>
         <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
           <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
+          <arg name="input/odometry" value="/localization/kinematic_state"/>
           <arg name="output/radar_detected_objects" value="detected_objects"/>
           <arg name="output/radar_tracked_objects" value="tracked_objects"/>
           <arg name="use_twist_compensation" value="false"/>
@@ -173,7 +173,7 @@
       <group>
         <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
           <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
+          <arg name="input/odometry" value="/localization/kinematic_state"/>
           <arg name="output/radar_detected_objects" value="detected_objects"/>
           <arg name="output/radar_tracked_objects" value="tracked_objects"/>
           <arg name="use_twist_compensation" value="false"/>
@@ -208,7 +208,7 @@
       <group>
         <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
           <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
+          <arg name="input/odometry" value="/localization/kinematic_state"/>
           <arg name="output/radar_detected_objects" value="detected_objects"/>
           <arg name="output/radar_tracked_objects" value="tracked_objects"/>
           <arg name="use_twist_compensation" value="false"/>
@@ -243,7 +243,7 @@
       <group>
         <include file="$(find-pkg-share autoware_radar_tracks_msgs_converter)/launch/radar_tracks_msgs_converter.launch.xml">
           <arg name="input/radar_objects" value="objects_raw"/>
-          <arg name="input/odometry" value="$(var odometry_topic)"/>
+          <arg name="input/odometry" value="/localization/kinematic_state"/>
           <arg name="output/radar_detected_objects" value="detected_objects"/>
           <arg name="output/radar_tracked_objects" value="tracked_objects"/>
           <arg name="param_path" value="$(var radar_tracks_msgs_converter_param_path)"/>


### PR DESCRIPTION
The input to `radar_tracks_msgs_converter` is actually an odometry topic `/localization/kinematic_state` instead of the velocity topic. After changing the topic to the throttled one with argument name changes, we need to change it here too

https://github.com/tier4/aip_launcher/pull/551