### PR TITLE
chore: imu bias scale corrector launch 

### DIFF
--- a/aip_x2_gen2_launch/config/gyro_bias_estimator.param.yaml
+++ b/aip_x2_gen2_launch/config/gyro_bias_estimator.param.yaml
@@ -2,5 +2,5 @@
   ros__parameters:
     gyro_bias_threshold: 0.008 # [rad/s]
     timer_callback_interval_sec: 0.5 # [sec]
-    diagnostics_updater_interval_sec: 0.5 # [sec]
+    diagnostics_updater_interval_sec: 0.1 # [sec]
     straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]

--- a/aip_x2_gen2_launch/config/gyro_scale_estimator.param.yaml
+++ b/aip_x2_gen2_launch/config/gyro_scale_estimator.param.yaml
@@ -1,0 +1,38 @@
+/**:
+  ros__parameters:
+    estimate_scale_init: 1.0
+    min_allowed_scale: 0.9
+    max_allowed_scale: 1.1
+    threshold_to_estimate_scale: 0.1
+    percentage_scale_rate_allow_correct: 0.04
+    alpha: 0.99
+    delay_gyro_ms: 170
+    samples_filter_pose_rate: 2
+    samples_filter_gyro_rate: 6
+    alpha_gyro: 0.0
+    buffer_size_gyro: 200
+    alpha_ndt_rate: 0.6
+
+    ekf_rate:
+      max_variance_p: 1e-8
+      variance_p_after: 5e-9
+      process_noise_q: 1e-14
+      process_noise_q_after: 1e-15
+      measurement_noise_r: 0.00007
+      measurement_noise_r_after: 0.00005
+      samples_to_init: 120
+      min_covariance: 1e-11
+
+    ekf_angle:
+      process_noise_q_angle: 1e-12
+      variance_p_angle: 5e-9
+      measurement_noise_r_angle: 0.00005
+      min_covariance_angle: 1e-11
+      decay_coefficient: 0.99999998
+
+    scale_imu_injection:
+      modify_imu_scale: false
+      scale_on_purpose: 1.0
+      bias_on_purpose: 0.0
+      drift_scale: 0.0
+      drift_bias: 0.0

--- a/aip_x2_gen2_launch/launch/imu.launch.xml
+++ b/aip_x2_gen2_launch/launch/imu.launch.xml
@@ -32,10 +32,16 @@
       <arg name="param_file" value="$(var imu_corrector_param_file)"/>
     </include>
 
+    <arg name="gyro_bias_estimator_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/gyro_bias_estimator.param.yaml"/>
+    <arg name="gyro_scale_estimator_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/gyro_scale_estimator.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="$(var imu_raw_name)"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
+      <arg name="input_pose_ndt" value="/localization/pose_estimator/pose_with_covariance"/>
+      <arg name="output_imu_scaled" value="/sensing/imu_output_scaled"/>
       <arg name="imu_corrector_param_file" value="$(var imu_corrector_param_file)"/>
+      <arg name="gyro_bias_estimator_param_file" value="$(var gyro_bias_estimator_param_file)"/>
+      <arg name="gyro_scale_estimator_param_file" value="$(var gyro_scale_estimator_param_file)"/>
     </include>
 
     <include file="$(find-pkg-share imu_monitor)/launch/imu_monitor.launch.xml">


### PR DESCRIPTION
This PR includes the necessary modifications to launch the latest gyro bias scale estimation node.

Features
-Adds 1 parameter file for scale estimation parameters.
-Modified IMU launcher by adding a missing parameter file and necessary NDT topic input.

-Tested with pilot.x2.