### PR TITLE
feat(x2gen2): add cropbox around max steering extent of tires

### DIFF
--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -55,10 +55,10 @@ def get_max_extents_from_wheel_center(
     Calculate bounding box extents for wheels when at maximum steering angle.
 
     Given a wheel of a given width and radius, and a maximum steering angle, calculate the maximum
-    extent from the wheel center in vehicle coordinates when the wheel is steered to its maximum 
+    extent from the wheel center in vehicle coordinates when the wheel is steered to its maximum
     angle.
 
-    Result is a tuple containing the maximum lateral (outward from tire center) and longitudinal 
+    Result is a tuple containing the maximum lateral (outward from tire center) and longitudinal
     (forward/backward from tire center) extents.
     """
     assert wheel_width_m > 0

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -111,6 +111,12 @@ def get_vehicle_info(context):
     p["wheels_min_lateral_offset"] = -(gp["wheel_tread"] / 2 + max_lat_offset)
     p["wheels_max_lateral_offset"] = gp["wheel_tread"] / 2 + max_lat_offset
     p["wheels_min_height_offset"] = 0.0
+
+    # The wheel height is scaled to 110% here (radius * 2) * 1.1 to account for
+    # possible suspension movement. There is no data at full steering on bumpy
+    # ground, so this is hard to verify. Might not be needed at all, or might
+    # need individual tuning for different vehicle platforms.
+    # Leaving it in for now, as it doesn't cause anyone trouble and *might* be needed.
     p["wheels_max_height_offset"] = wheel_radius * 2.2
 
     return p

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 import logging
-from math import atan2, cos, pi, sin, sqrt
+from math import atan2
+from math import cos
+from math import pi
+from math import sin
+from math import sqrt
 import os
 
 import launch
@@ -62,9 +66,7 @@ def get_max_extents_from_wheel_center(
     if angle_corner < max_steer_angle_rad:
         max_longitudinal_offset = d_center_to_corner
     else:
-        max_longitudinal_offset = d_center_to_corner * cos(
-            max_steer_angle_rad - angle_corner
-        )
+        max_longitudinal_offset = d_center_to_corner * cos(max_steer_angle_rad - angle_corner)
 
     max_lateral_offset = d_center_to_corner * sin(max_steer_angle_rad + angle_corner)
 
@@ -200,7 +202,7 @@ def make_nebula_node(context, as_composable_node, env=None):
 
 def make_preprocessor_nodes(context):
     vehicle_info = get_vehicle_info(context)
-    
+
     cropbox_parameters_self = create_parameter_dict("input_frame", "output_frame")
     cropbox_parameters_self["negative"] = True
     cropbox_parameters_self["processing_time_threshold_sec"] = 0.01

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from math import atan2, cos, pi, sin, sqrt
 import os
 
 import launch
@@ -43,6 +44,36 @@ def get_lidar_make(sensor_name):
     return "unrecognized_sensor_model"
 
 
+def get_max_extents_from_wheel_center(
+    wheel_width_m: float, wheel_radius_m: float, max_steer_angle_rad: float
+):
+    """
+    Given a wheel of a given width and radius, and a maximum steering angle, calculate the maximum
+    extent from the wheel center in vehicle coordinates when the wheel is steered to its maximum angle.
+    """
+    assert wheel_width_m > 0
+    assert wheel_radius_m > 0
+    assert max_steer_angle_rad < 90 / 180 * pi
+
+    w_half = wheel_width_m / 2
+    d_center_to_corner = sqrt(w_half**2 + wheel_radius_m**2)
+    angle_corner = atan2(w_half, wheel_radius_m)
+
+    if angle_corner < max_steer_angle_rad:
+        max_longitudinal_offset = d_center_to_corner
+    else:
+        max_longitudinal_offset = d_center_to_corner * cos(
+            max_steer_angle_rad - angle_corner
+        )
+
+    max_lateral_offset = d_center_to_corner * sin(max_steer_angle_rad + angle_corner)
+
+    assert max_lateral_offset > 0
+    assert max_longitudinal_offset > 0
+
+    return max_lateral_offset, max_longitudinal_offset
+
+
 def get_vehicle_info(context):
     # TODO(TIER IV): Use Parameter Substitution after we drop Galactic support
     # https://github.com/ros2/launch_ros/blob/master/launch_ros/launch_ros/substitutions/parameter.py
@@ -58,6 +89,22 @@ def get_vehicle_info(context):
     p["max_lateral_offset"] = gp["wheel_tread"] / 2.0 + gp["left_overhang"]
     p["min_height_offset"] = 0.0
     p["max_height_offset"] = gp["vehicle_height"]
+
+    wheel_width = gp["wheel_width"]
+    wheel_radius = gp["wheel_radius"]
+    max_steer_angle_rad = gp["max_steer_angle"]
+
+    max_lat_offset, max_lon_offset = get_max_extents_from_wheel_center(
+        wheel_width, wheel_radius, max_steer_angle_rad
+    )
+
+    p["wheels_min_longitudinal_offset"] = gp["wheel_base"] - max_lon_offset
+    p["wheels_max_longitudinal_offset"] = gp["wheel_base"] + max_lon_offset
+    p["wheels_min_lateral_offset"] = -(gp["wheel_tread"] / 2 + max_lat_offset)
+    p["wheels_max_lateral_offset"] = gp["wheel_tread"] / 2 + max_lat_offset
+    p["wheels_min_height_offset"] = 0.0
+    p["wheels_max_height_offset"] = wheel_radius * 2.2
+
     return p
 
 
@@ -152,17 +199,29 @@ def make_nebula_node(context, as_composable_node, env=None):
 
 
 def make_preprocessor_nodes(context):
-    cropbox_parameters = create_parameter_dict("input_frame", "output_frame")
-    cropbox_parameters["negative"] = True
-    cropbox_parameters["processing_time_threshold_sec"] = 0.01
-
     vehicle_info = get_vehicle_info(context)
-    cropbox_parameters["min_x"] = vehicle_info["min_longitudinal_offset"]
-    cropbox_parameters["max_x"] = vehicle_info["max_longitudinal_offset"]
-    cropbox_parameters["min_y"] = vehicle_info["min_lateral_offset"]
-    cropbox_parameters["max_y"] = vehicle_info["max_lateral_offset"]
-    cropbox_parameters["min_z"] = vehicle_info["min_height_offset"]
-    cropbox_parameters["max_z"] = vehicle_info["max_height_offset"]
+    
+    cropbox_parameters_self = create_parameter_dict("input_frame", "output_frame")
+    cropbox_parameters_self["negative"] = True
+    cropbox_parameters_self["processing_time_threshold_sec"] = 0.01
+
+    cropbox_parameters_self["min_x"] = vehicle_info["min_longitudinal_offset"]
+    cropbox_parameters_self["max_x"] = vehicle_info["max_longitudinal_offset"]
+    cropbox_parameters_self["min_y"] = vehicle_info["min_lateral_offset"]
+    cropbox_parameters_self["max_y"] = vehicle_info["max_lateral_offset"]
+    cropbox_parameters_self["min_z"] = vehicle_info["min_height_offset"]
+    cropbox_parameters_self["max_z"] = vehicle_info["max_height_offset"]
+
+    cropbox_parameters_wheels = create_parameter_dict("input_frame", "output_frame")
+    cropbox_parameters_wheels["negative"] = True
+    cropbox_parameters_wheels["processing_time_threshold_sec"] = 0.01
+
+    cropbox_parameters_wheels["min_x"] = vehicle_info["wheels_min_longitudinal_offset"]
+    cropbox_parameters_wheels["max_x"] = vehicle_info["wheels_max_longitudinal_offset"]
+    cropbox_parameters_wheels["min_y"] = vehicle_info["wheels_min_lateral_offset"]
+    cropbox_parameters_wheels["max_y"] = vehicle_info["wheels_max_lateral_offset"]
+    cropbox_parameters_wheels["min_z"] = vehicle_info["wheels_min_height_offset"]
+    cropbox_parameters_wheels["max_z"] = vehicle_info["wheels_max_height_offset"]
 
     nodes = []
 
@@ -175,7 +234,21 @@ def make_preprocessor_nodes(context):
                 ("input", "pointcloud_raw_ex"),
                 ("output", "self_cropped/pointcloud_ex"),
             ],
-            parameters=[cropbox_parameters],
+            parameters=[cropbox_parameters_self],
+            extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        )
+    )
+
+    nodes.append(
+        ComposableNode(
+            package="autoware_pointcloud_preprocessor",
+            plugin="autoware::pointcloud_preprocessor::CropBoxFilterComponent",
+            name="crop_box_filter_wheels",
+            remappings=[
+                ("input", "self_cropped/pointcloud_ex"),
+                ("output", "wheels_cropped/pointcloud_ex"),
+            ],
+            parameters=[cropbox_parameters_wheels],
             extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         )
     )
@@ -191,7 +264,7 @@ def make_preprocessor_nodes(context):
                     "/sensing/vehicle_velocity_converter/twist_with_covariance",
                 ),
                 ("~/input/imu", "/sensing/imu/imu_data"),
-                ("~/input/pointcloud", "self_cropped/pointcloud_ex"),
+                ("~/input/pointcloud", "wheels_cropped/pointcloud_ex"),
                 ("~/output/pointcloud", "rectified/pointcloud_ex"),
             ],
             parameters=[
@@ -282,21 +355,27 @@ def make_cuda_preprocessor_nodes(context):
     preprocessor_parameters = {}
     preprocessor_parameters["crop_box.min_x"] = [
         vehicle_info["min_longitudinal_offset"],
+        vehicle_info["wheels_min_longitudinal_offset"],
     ]
     preprocessor_parameters["crop_box.max_x"] = [
         vehicle_info["max_longitudinal_offset"],
+        vehicle_info["wheels_max_longitudinal_offset"],
     ]
     preprocessor_parameters["crop_box.min_y"] = [
         vehicle_info["min_lateral_offset"],
+        vehicle_info["wheels_min_lateral_offset"],
     ]
     preprocessor_parameters["crop_box.max_y"] = [
         vehicle_info["max_lateral_offset"],
+        vehicle_info["wheels_max_lateral_offset"],
     ]
     preprocessor_parameters["crop_box.min_z"] = [
         vehicle_info["min_height_offset"],
+        vehicle_info["wheels_min_height_offset"],
     ]
     preprocessor_parameters["crop_box.max_z"] = [
         vehicle_info["max_height_offset"],
+        vehicle_info["wheels_max_height_offset"],
     ]
 
     return [

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -52,8 +52,14 @@ def get_max_extents_from_wheel_center(
     wheel_width_m: float, wheel_radius_m: float, max_steer_angle_rad: float
 ):
     """
+    Calculate bounding box extents for wheels when at maximum steering angle.
+
     Given a wheel of a given width and radius, and a maximum steering angle, calculate the maximum
-    extent from the wheel center in vehicle coordinates when the wheel is steered to its maximum angle.
+    extent from the wheel center in vehicle coordinates when the wheel is steered to its maximum 
+    angle.
+
+    Result is a tuple containing the maximum lateral (outward from tire center) and longitudinal 
+    (forward/backward from tire center) extents.
     """
     assert wheel_width_m > 0
     assert wheel_radius_m > 0


### PR DESCRIPTION
## Summary

This PR addresses [`RT0-39017`: [x2][v4.3.0][塩尻]市役所出口での自車タイヤによるobstacle_stopが出現し立往生](https://tier4.atlassian.net/browse/RT0-39017).

It does so by introducing a cropbox around the maximum steering extent of the front tires.

## Method

Given a maximum steering angle $\varphi = \texttt{max\\_steer\\_angle}$, and the wheel width and height, the maximum extent in longitudinal (forward) and lateral (outward) direction of the vehicle are calculated:

<img width="1600" height="706" alt="image" src="https://github.com/user-attachments/assets/cde191f8-85b0-499f-97a5-fcf1b1084cb4" />

$d = \sqrt((\texttt{wheel\\_width} \div 2)^2 + \texttt{wheel\\_radius}^2)$
$\alpha = atan(\frac{\texttt{wheel\\_width} \div 2}{\texttt{wheel\\_radius}})$

Note that the corners of the wheel ($d$ from the wheel center) will always be the outermost points. Thus, `max_lat` and `max_lon` can be calculated using just $d$.

As long as $\alpha + \varphi < 90^{\circ}$, `max_lat` can be taken from $d$ rotated by $\alpha + \varphi$. It is expected this is always the case (steering angle would be unphysically huge otherwise).

For longitude, the relevant tier corner might have rotated so far that the extent shrunk again, if $\alpha < \varphi$. `max_lon` in this case is thus just $d$.

## Known limitations

* For `cpu` mode, an additional crop box filter node is added to the pipeline. This increases latency. It is expected that CPU mode will not be used in production.
* To keep the code small, the wheel cropbox is always enabled (there is no parameter to turn it off for certain LiDARs). This will increase computational load as it is strictly only required for `{left,right}_lower` LiDARs. For CUDA, impact should be tiny.
* Wheel height has been somewhat arbitrarily scaled to 110% (`wheel_radius * 2.2`) to account for possible impact from suspension/bumps.

## Evaluation

These videos correspond to the rosbags uploaded to the Jira ticket. Rosbag names correspond to video names.
Tested with both `cuda` and `cpu` pipeline modes.

[b3902d62-9777-496d-846b-39c3db7b9dcf_2025-08-25-11-32-01_p0900_1.webm](https://github.com/user-attachments/assets/ee55b10c-e35c-4abc-af50-783062cff1c8)

[b3902d62-9777-496d-846b-39c3db7b9dcf_2025-08-19-11-06-13_p0900_5.webm](https://github.com/user-attachments/assets/f2c9ef93-3dae-4561-bb48-21c4b8078afc)

[b3902d62-9777-496d-846b-39c3db7b9dcf_2025-08-19-11-21-37_p0900_5.webm](https://github.com/user-attachments/assets/ca72fc28-bb6e-4069-bb09-2afa5f81eeb6)

[b3902d62-9777-496d-846b-39c3db7b9dcf_2025-08-22-11-49-32_p0900_4.webm](https://github.com/user-attachments/assets/f42cbf69-3613-4e72-b629-556be97b8baf)

[b3902d62-9777-496d-846b-39c3db7b9dcf_2025-08-22-14-46-37_p0900_4.webm](https://github.com/user-attachments/assets/4e56761e-3999-4366-b7b6-82b5eb231c24)

[b3902d62-9777-496d-846b-39c3db7b9dcf_2025-08-25-10-58-38_p0900_3.webm](https://github.com/user-attachments/assets/7754daa4-8785-4699-999c-4b6c15512360)

[b3902d62-9777-496d-846b-39c3db7b9dcf_2025-08-25-11-09-41_p0900_4.webm](https://github.com/user-attachments/assets/cb82bbc2-ce20-4d49-a8f7-fde286aca117)
