### PR TITLE
fix: solving conflict Backport 572 to beta2/v0.48

### DIFF
--- a/aip_x1_launch/config/gyro_bias_estimator.param.yaml
+++ b/aip_x1_launch/config/gyro_bias_estimator.param.yaml
@@ -2,5 +2,5 @@
   ros__parameters:
     gyro_bias_threshold: 0.008 # [rad/s]
     timer_callback_interval_sec: 0.5 # [sec]
-    diagnostics_updater_interval_sec: 0.5 # [sec]
+    diagnostics_updater_interval_sec: 0.1 # [sec]
     straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]

--- a/aip_x1_launch/config/gyro_scale_estimator.param.yaml
+++ b/aip_x1_launch/config/gyro_scale_estimator.param.yaml
@@ -1,0 +1,42 @@
+/**:
+  ros__parameters:
+    estimate_scale_init: 1.0
+    min_allowed_scale: 0.9
+    max_allowed_scale: 1.1
+    threshold_to_estimate_scale: 0.1
+    percentage_scale_rate_allow_correct: 0.04
+    alpha: 0.99
+    delay_gyro_ms: 170
+    samples_filter_pose_rate: 2
+    samples_filter_gyro_rate: 6
+    alpha_gyro: 0.0
+    buffer_size_gyro: 200
+    alpha_ndt_rate: 0.6
+
+    ekf_rate:
+      max_variance_p: 1e-8
+      variance_p_after: 5e-9
+      process_noise_q: 1e-14
+      process_noise_q_after: 1e-15
+      measurement_noise_r: 0.00007
+      measurement_noise_r_after: 0.00005
+      samples_to_init: 120
+      min_covariance: 1e-11
+
+    ekf_angle:
+      process_noise_q_angle: 1e-12
+      variance_p_angle: 5e-9
+      measurement_noise_r_angle: 0.00005
+      min_covariance_angle: 1e-11
+      decay_coefficient: 0.99999998
+
+    scale_imu_injection:
+      modify_imu_scale: false
+      scale_on_purpose: 1.0
+      bias_on_purpose: 0.0
+      drift_scale: 0.0
+      drift_bias: 0.0
+
+    on_off_correction:
+      correct_for_bias: false
+      correct_for_scale: true

--- a/aip_x1_launch/launch/imu.launch.xml
+++ b/aip_x1_launch/launch/imu.launch.xml
@@ -22,17 +22,23 @@
 
     <arg name="imu_raw_name" default="tamagawa/imu_raw"/>
     <arg name="imu_corrector_param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x1/imu_corrector.param.yaml"/>
+    <arg name="gyro_scale_estimator_param_file" default="$(find-pkg-share aip_x1_launch)/config/gyro_scale_estimator.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="$(var imu_raw_name)"/>
       <arg name="output_topic" value="imu_data" />
       <arg name="param_file" value="$(var imu_corrector_param_file)"/>
+      <arg name="param_scale_file" value="$(var gyro_scale_estimator_param_file)"/>
     </include>
 
     <arg name="gyro_bias_estimator_param_file" default="$(find-pkg-share aip_x1_launch)/config/gyro_bias_estimator.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="$(var imu_raw_name)"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
+      <arg name="input_pose_ndt" value="/localization/pose_estimator/pose_with_covariance"/>
+      <arg name="output_imu_scaled" value="/sensing/imu_output_scaled"/>
       <arg name="imu_corrector_param_file" value="$(var imu_corrector_param_file)"/>
+      <arg name="gyro_bias_estimator_param_file" value="$(var gyro_bias_estimator_param_file)"/>
+      <arg name="gyro_scale_estimator_param_file" value="$(var gyro_scale_estimator_param_file)"/>
     </include>
   </group>
 

--- a/aip_x2_gen2_launch/config/gyro_scale_estimator.param.yaml
+++ b/aip_x2_gen2_launch/config/gyro_scale_estimator.param.yaml
@@ -1,0 +1,42 @@
+/**:
+  ros__parameters:
+    estimate_scale_init: 1.0
+    min_allowed_scale: 0.9
+    max_allowed_scale: 1.1
+    threshold_to_estimate_scale: 0.1
+    percentage_scale_rate_allow_correct: 0.04
+    alpha: 0.99
+    delay_gyro_ms: 170
+    samples_filter_pose_rate: 2
+    samples_filter_gyro_rate: 6
+    alpha_gyro: 0.0
+    buffer_size_gyro: 200
+    alpha_ndt_rate: 0.6
+
+    ekf_rate:
+      max_variance_p: 1e-8
+      variance_p_after: 5e-9
+      process_noise_q: 1e-14
+      process_noise_q_after: 1e-15
+      measurement_noise_r: 0.00007
+      measurement_noise_r_after: 0.00005
+      samples_to_init: 120
+      min_covariance: 1e-11
+
+    ekf_angle:
+      process_noise_q_angle: 1e-12
+      variance_p_angle: 5e-9
+      measurement_noise_r_angle: 0.00005
+      min_covariance_angle: 1e-11
+      decay_coefficient: 0.99999998
+
+    scale_imu_injection:
+      modify_imu_scale: false
+      scale_on_purpose: 1.0
+      bias_on_purpose: 0.0
+      drift_scale: 0.0
+      drift_bias: 0.0
+
+    on_off_correction:
+      correct_for_bias: false
+      correct_for_scale: false

--- a/aip_x2_gen2_launch/launch/imu.launch.xml
+++ b/aip_x2_gen2_launch/launch/imu.launch.xml
@@ -26,16 +26,23 @@
 
     <arg name="imu_raw_name" default="tamagawa/imu_raw"/>
     <arg name="imu_corrector_param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_x2_gen2/imu_corrector.param.yaml"/>
+    <arg name="gyro_scale_estimator_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/gyro_scale_estimator.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="$(var imu_raw_name)"/>
       <arg name="output_topic" value="imu_data"/>
       <arg name="param_file" value="$(var imu_corrector_param_file)"/>
+      <arg name="param_scale_file" value="$(var gyro_scale_estimator_param_file)"/>
     </include>
 
+    <arg name="gyro_bias_estimator_param_file" default="$(find-pkg-share aip_x2_gen2_launch)/config/gyro_bias_estimator.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="$(var imu_raw_name)"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
+      <arg name="input_pose_ndt" value="/localization/pose_estimator/pose_with_covariance"/>
+      <arg name="output_imu_scaled" value="/sensing/imu_output_scaled"/>
       <arg name="imu_corrector_param_file" value="$(var imu_corrector_param_file)"/>
+      <arg name="gyro_bias_estimator_param_file" value="$(var gyro_bias_estimator_param_file)"/>
+      <arg name="gyro_scale_estimator_param_file" value="$(var gyro_scale_estimator_param_file)"/>
     </include>
 
     <include file="$(find-pkg-share imu_monitor)/launch/imu_monitor.launch.xml">

--- a/aip_xx1_gen2_launch/config/gyro_scale_estimator.param.yaml
+++ b/aip_xx1_gen2_launch/config/gyro_scale_estimator.param.yaml
@@ -1,0 +1,42 @@
+/**:
+  ros__parameters:
+    estimate_scale_init: 1.0
+    min_allowed_scale: 0.9
+    max_allowed_scale: 1.1
+    threshold_to_estimate_scale: 0.1
+    percentage_scale_rate_allow_correct: 0.04
+    alpha: 0.99
+    delay_gyro_ms: 170
+    samples_filter_pose_rate: 2
+    samples_filter_gyro_rate: 6
+    alpha_gyro: 0.0
+    buffer_size_gyro: 200
+    alpha_ndt_rate: 0.6
+
+    ekf_rate:
+      max_variance_p: 1e-8
+      variance_p_after: 5e-9
+      process_noise_q: 1e-14
+      process_noise_q_after: 1e-15
+      measurement_noise_r: 0.00007
+      measurement_noise_r_after: 0.00005
+      samples_to_init: 120
+      min_covariance: 1e-11
+
+    ekf_angle:
+      process_noise_q_angle: 1e-12
+      variance_p_angle: 5e-9
+      measurement_noise_r_angle: 0.00005
+      min_covariance_angle: 1e-11
+      decay_coefficient: 0.99999998
+
+    scale_imu_injection:
+      modify_imu_scale: false
+      scale_on_purpose: 1.0
+      bias_on_purpose: 0.0
+      drift_scale: 0.0
+      drift_bias: 0.0
+
+    on_off_correction:
+      correct_for_bias: false
+      correct_for_scale: false

--- a/aip_xx1_gen2_launch/launch/imu.launch.xml
+++ b/aip_xx1_gen2_launch/launch/imu.launch.xml
@@ -37,10 +37,12 @@
     <!-- IMU Correction launch-->
     <arg name="imu_raw_name" default="tamagawa/imu_raw"/>
     <arg name="imu_corrector_param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_xx1_gen2/imu_corrector.param.yaml"/>
+    <arg name="gyro_scale_estimator_param_file" default="$(find-pkg-share aip_xx1_gen2_launch)/config/gyro_scale_estimator.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="$(var imu_raw_name)"/>
       <arg name="output_topic" value="imu_data"/>
       <arg name="param_file" value="$(var imu_corrector_param_file)"/>
+      <arg name="param_scale_file" value="$(var gyro_scale_estimator_param_file)"/>
     </include>
 
     <!-- Gyro Bias Estimator-->
@@ -48,8 +50,11 @@
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="$(var imu_raw_name)"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
-      <arg name="imu_corrector_param_file" value="$(var imu_corrector_param_file)"/>
       <arg name="gyro_bias_estimator_param_file" value="$(var gyro_bias_estimator_param_file)"/>
+      <arg name="input_pose_ndt" value="/localization/pose_estimator/pose_with_covariance"/>
+      <arg name="output_imu_scaled" value="/sensing/imu_output_scaled"/>
+      <arg name="imu_corrector_param_file" value="$(var imu_corrector_param_file)"/>
+      <arg name="gyro_scale_estimator_param_file" value="$(var gyro_scale_estimator_param_file)"/>
     </include>
   </group>
 

--- a/aip_xx1_launch/config/gyro_bias_estimator.param.yaml
+++ b/aip_xx1_launch/config/gyro_bias_estimator.param.yaml
@@ -2,5 +2,5 @@
   ros__parameters:
     gyro_bias_threshold: 0.008 # [rad/s]
     timer_callback_interval_sec: 0.5 # [sec]
-    diagnostics_updater_interval_sec: 0.5 # [sec]
+    diagnostics_updater_interval_sec: 0.1 # [sec]
     straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]

--- a/aip_xx1_launch/config/gyro_scale_estimator.param.yaml
+++ b/aip_xx1_launch/config/gyro_scale_estimator.param.yaml
@@ -1,0 +1,42 @@
+/**:
+  ros__parameters:
+    estimate_scale_init: 1.0
+    min_allowed_scale: 0.9
+    max_allowed_scale: 1.1
+    threshold_to_estimate_scale: 0.1
+    percentage_scale_rate_allow_correct: 0.04
+    alpha: 0.99
+    delay_gyro_ms: 170
+    samples_filter_pose_rate: 2
+    samples_filter_gyro_rate: 6
+    alpha_gyro: 0.0
+    buffer_size_gyro: 200
+    alpha_ndt_rate: 0.6
+
+    ekf_rate:
+      max_variance_p: 1e-8
+      variance_p_after: 5e-9
+      process_noise_q: 1e-14
+      process_noise_q_after: 1e-15
+      measurement_noise_r: 0.00007
+      measurement_noise_r_after: 0.00005
+      samples_to_init: 120
+      min_covariance: 1e-11
+
+    ekf_angle:
+      process_noise_q_angle: 1e-12
+      variance_p_angle: 5e-9
+      measurement_noise_r_angle: 0.00005
+      min_covariance_angle: 1e-11
+      decay_coefficient: 0.99999998
+
+    scale_imu_injection:
+      modify_imu_scale: false
+      scale_on_purpose: 1.0
+      bias_on_purpose: 0.0
+      drift_scale: 0.0
+      drift_bias: 0.0
+
+    on_off_correction:
+      correct_for_bias: false
+      correct_for_scale: true

--- a/aip_xx1_launch/launch/imu.launch.xml
+++ b/aip_xx1_launch/launch/imu.launch.xml
@@ -17,18 +17,23 @@
 
     <arg name="imu_raw_name" default="tamagawa/imu_raw"/>
     <arg name="imu_corrector_param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/aip_xx1/imu_corrector.param.yaml"/>
+    <arg name="gyro_scale_estimator_param_file" default="$(find-pkg-share aip_xx1_launch)/config/gyro_scale_estimator.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="$(var imu_raw_name)"/>
       <arg name="output_topic" value="imu_data"/>
       <arg name="param_file" value="$(var imu_corrector_param_file)"/>
+      <arg name="param_scale_file" value="$(var gyro_scale_estimator_param_file)"/>
     </include>
 
     <arg name="gyro_bias_estimator_param_file" default="$(find-pkg-share aip_xx1_launch)/config/gyro_bias_estimator.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="$(var imu_raw_name)"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
+      <arg name="input_pose_ndt" value="/localization/pose_estimator/pose_with_covariance"/>
+      <arg name="output_imu_scaled" value="/sensing/imu_output_scaled"/>
       <arg name="imu_corrector_param_file" value="$(var imu_corrector_param_file)"/>
       <arg name="gyro_bias_estimator_param_file" value="$(var gyro_bias_estimator_param_file)"/>
+      <arg name="gyro_scale_estimator_param_file" value="$(var gyro_scale_estimator_param_file)"/>
     </include>
   </group>
 


### PR DESCRIPTION
PR to solve the conflict when cherry-picking may have skipped a commit

* chore: launcher mode to enable disable bias scale correction

* ci(pre-commit): autofix

* chore: mod files to imu x1 xx1 proj

* adding parameters xx1_gen2 to enable disable scale bias correction

---------

(cherry picked from commit 85008c48efa090e36568d758a3bfc88ee211a4ff)