### PR TITLE
feat(aip_x2_gen2_launch): enable gnss diagnostics publishers

### DIFF
--- a/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
+++ b/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
@@ -91,6 +91,8 @@
       pose: false
       twist: false
       diagnostics: true
+      aimplusstatus: true
+      galauthstatus: true
       # For GNSS Rx only
       gpgsa: false
       gpgsv: false


### PR DESCRIPTION
Latest [PR](https://github.com/tier4/aip_launcher/pull/567) enabled only monitoring. This PR activate publishers.