### PR TITLE
fix: dummy diag/lidar visibility and imu rate

### DIFF
--- a/aip_x2_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_x2_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -20,7 +20,7 @@
       "imu_monitor: yaw_rate_status": default
       "topic_state_monitor_imu_data: imu_topic_status": default
       "gyro_bias_scale_validator: gyro_bias_scale_validator": default
-      "tamagawa_imu_driver: rate bound check": default
+      "/sensing/imu/tamagawa/tag_can_driver: rate bound check": default
 
       # lidar
       "/sensing/lidar/front_lower/hesai_ros_wrapper_node: hesai_status": default
@@ -79,7 +79,7 @@
 
       "concatenate_data: /sensing/lidar/concatenate_data": default
 
-      "polar_voxel_outlier_filter: polar_voxel_outlier_filter: /sensing/lidar/right_upper: visibility_validation": default
+      "polar_voxel_outlier_filter: /sensing/lidar/right_upper: visibility_validation": default
 
       # camera
       "v4l2_camera_camera0: camera0_diagnostics": default


### PR DESCRIPTION
lidar visibilityと imu rateのdiag名が間違ってたので修正
[link](https://star4.slack.com/archives/C07K9RBUQR3/p1757577386160879?thread_ts=1757547048.280059&cid=C07K9RBUQR3)

[launcher修正](https://github.com/tier4/autoware_launch.x2/pull/1550)とともに取り込まれる必要があるので注意。