### PR TITLE
chore(x2gen2): extend crop boxes so points hitting LiDARs are excluded

### DIFF
--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -112,12 +112,12 @@ def get_vehicle_info(context):
     p["wheels_max_lateral_offset"] = gp["wheel_tread"] / 2 + max_lat_offset
     p["wheels_min_height_offset"] = 0.0
 
-    # The wheel height is scaled to 110% here (radius * 2) * 1.1 to account for
-    # possible suspension movement. There is no data at full steering on bumpy
-    # ground, so this is hard to verify. Might not be needed at all, or might
-    # need individual tuning for different vehicle platforms.
-    # Leaving it in for now, as it doesn't cause anyone trouble and *might* be needed.
-    p["wheels_max_height_offset"] = wheel_radius * 2.2
+    # The left/right LiDARs are hitting each other, so we extend the wheel crop box to the vehicle
+    # height. The LiDARs are included in this crop box. Other options would be
+    # * add a crop box per LiDAR (inefficient, lots of additional crop boxes)
+    # * make the vehicle crop box larger (poses safety risks for small objects around the vehicle)
+    # Thus, currently this is the best compromise.
+    p["wheels_max_height_offset"] = gp["vehicle_height"]
 
     return p
 

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -45,7 +45,6 @@ SELF_CROP_BOX_FRONT_PADDING = 0.05
 WHEELS_CROP_BOX_SIDE_PADDING = 0.05
 
 
-
 def get_lidar_make(sensor_name):
     if sensor_name[:6].lower() == "pandar":
         return "Hesai", ".csv"
@@ -226,7 +225,9 @@ def make_preprocessor_nodes(context):
     cropbox_parameters_self["processing_time_threshold_sec"] = 0.01
 
     cropbox_parameters_self["min_x"] = vehicle_info["min_longitudinal_offset"]
-    cropbox_parameters_self["max_x"] = vehicle_info["max_longitudinal_offset"] + SELF_CROP_BOX_FRONT_PADDING
+    cropbox_parameters_self["max_x"] = (
+        vehicle_info["max_longitudinal_offset"] + SELF_CROP_BOX_FRONT_PADDING
+    )
     cropbox_parameters_self["min_y"] = vehicle_info["min_lateral_offset"]
     cropbox_parameters_self["max_y"] = vehicle_info["max_lateral_offset"]
     cropbox_parameters_self["min_z"] = vehicle_info["min_height_offset"]
@@ -238,8 +239,12 @@ def make_preprocessor_nodes(context):
 
     cropbox_parameters_wheels["min_x"] = vehicle_info["wheels_min_longitudinal_offset"]
     cropbox_parameters_wheels["max_x"] = vehicle_info["wheels_max_longitudinal_offset"]
-    cropbox_parameters_wheels["min_y"] = vehicle_info["wheels_min_lateral_offset"] - WHEELS_CROP_BOX_SIDE_PADDING
-    cropbox_parameters_wheels["max_y"] = vehicle_info["wheels_max_lateral_offset"] + WHEELS_CROP_BOX_SIDE_PADDING
+    cropbox_parameters_wheels["min_y"] = (
+        vehicle_info["wheels_min_lateral_offset"] - WHEELS_CROP_BOX_SIDE_PADDING
+    )
+    cropbox_parameters_wheels["max_y"] = (
+        vehicle_info["wheels_max_lateral_offset"] + WHEELS_CROP_BOX_SIDE_PADDING
+    )
     cropbox_parameters_wheels["min_z"] = vehicle_info["wheels_min_height_offset"]
     cropbox_parameters_wheels["max_z"] = vehicle_info["wheels_max_height_offset"]
 

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -39,6 +39,12 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+# These are not nice, but currently needed because the vehicle sometimes hits itself.
+# FIXME: Find a better solution.
+SELF_CROP_BOX_FRONT_PADDING = 0.05
+WHEELS_CROP_BOX_SIDE_PADDING = 0.05
+
+
 
 def get_lidar_make(sensor_name):
     if sensor_name[:6].lower() == "pandar":
@@ -220,7 +226,7 @@ def make_preprocessor_nodes(context):
     cropbox_parameters_self["processing_time_threshold_sec"] = 0.01
 
     cropbox_parameters_self["min_x"] = vehicle_info["min_longitudinal_offset"]
-    cropbox_parameters_self["max_x"] = vehicle_info["max_longitudinal_offset"]
+    cropbox_parameters_self["max_x"] = vehicle_info["max_longitudinal_offset"] + SELF_CROP_BOX_FRONT_PADDING
     cropbox_parameters_self["min_y"] = vehicle_info["min_lateral_offset"]
     cropbox_parameters_self["max_y"] = vehicle_info["max_lateral_offset"]
     cropbox_parameters_self["min_z"] = vehicle_info["min_height_offset"]
@@ -232,8 +238,8 @@ def make_preprocessor_nodes(context):
 
     cropbox_parameters_wheels["min_x"] = vehicle_info["wheels_min_longitudinal_offset"]
     cropbox_parameters_wheels["max_x"] = vehicle_info["wheels_max_longitudinal_offset"]
-    cropbox_parameters_wheels["min_y"] = vehicle_info["wheels_min_lateral_offset"]
-    cropbox_parameters_wheels["max_y"] = vehicle_info["wheels_max_lateral_offset"]
+    cropbox_parameters_wheels["min_y"] = vehicle_info["wheels_min_lateral_offset"] - WHEELS_CROP_BOX_SIDE_PADDING
+    cropbox_parameters_wheels["max_y"] = vehicle_info["wheels_max_lateral_offset"] + WHEELS_CROP_BOX_SIDE_PADDING
     cropbox_parameters_wheels["min_z"] = vehicle_info["wheels_min_height_offset"]
     cropbox_parameters_wheels["max_z"] = vehicle_info["wheels_max_height_offset"]
 


### PR DESCRIPTION
See https://tier4.atlassian.net/browse/RT0-39270.

<img width="1981" height="1716" alt="image" src="https://github.com/user-attachments/assets/04ad9472-3f97-4f9b-ad78-3f66e858d5c4" />

* Extended the wheel crop box to extend to the top of the bus.
* There are ugly hard-coded paddings for the vehicle params now, as they were not enough.
* There are still some single noise points around the bus, even in areas different from the wheels and LiDARs.

