### PR TITLE
chore: adjust ring_outlier_filter

### DIFF
--- a/aip_x2_gen2_launch/config/ring_outlier_filter_node.param.yaml
+++ b/aip_x2_gen2_launch/config/ring_outlier_filter_node.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    distance_ratio: 1.03
+    distance_ratio: 1.1
     object_length_threshold: 0.05
     max_rings_num: 128
     max_points_num_per_ring: 4000


### PR DESCRIPTION
- Increase `distance_ratio` to avoid filtering out pointcloud which are close to LiDAR (OT128). 
- Discussed lack thread: https://star4.slack.com/archives/C057JDFS5M2/p1758016466224529?thread_ts=1757478382.884309&cid=C057JDFS5M2 
- Testing result 
  - Confirmed most pointcloud of upper part of manequin are remained
    - [Screencast from 2025年09月16日 18時36分31秒.webm](https://github.com/user-attachments/assets/12d95af2-0d56-4410-a9e8-13c65dad3210)
  - Confimed no noise pointcloud are apppeared surrounding left_lower, right_lower lidar
    -  [Screencast from 2025年09月16日 18時47分38秒.webm](https://github.com/user-attachments/assets/784f42bb-6b9d-45e5-a0c3-5acb2f41b662)

