### PR TITLE
chore(nebula_node_container): change input topic to give better visibility results

### DIFF
--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -508,9 +508,10 @@ def launch_setup(context, *args, **kwargs):
     env = make_agnocast_env(context) if use_agnocast else {}
 
     use_blockage_diag = IfCondition(LaunchConfiguration("enable_blockage_diag")).evaluate(context)
-    polar_voxel_outlier_filter_mode = LaunchConfiguration(
-        "polar_voxel_visibility_estimation_mode"
-    ).perform(context)
+
+    use_polar_voxel_outlier_filter = (
+        LaunchConfiguration("polar_voxel_visibility_estimation_mode").perform(context) != "disable"
+    )
 
     shared_container_nodes = []
     lidar_specific_container_nodes = []
@@ -539,41 +540,39 @@ def launch_setup(context, *args, **kwargs):
                 logger.warning("This pipeline mode may perform better when using Agnocast")
 
             shared_container_nodes.extend(make_cuda_preprocessor_nodes(context))
-            list_preprocessor_uses = shared_container_nodes
 
-            if use_blockage_diag:
+            if use_blockage_diag or use_polar_voxel_outlier_filter:
                 lidar_specific_container_nodes.append(make_nebula_node(context, True))
+            if use_polar_voxel_outlier_filter:
+                lidar_specific_container_nodes.extend(make_polar_voxel_outlier_filter_node(context))
+            if use_blockage_diag:
                 lidar_specific_container_nodes.extend(make_blockage_diag_nodes(context))
-            else:
-                standalone_nodes.append(make_nebula_node(context, False, env))
         case "cuda-all-in-one":
             shared_container_nodes.extend(make_cuda_preprocessor_nodes(context))
             shared_container_nodes.append(make_nebula_node(context, True))
-            list_preprocessor_uses = shared_container_nodes
 
             if use_blockage_diag:
                 shared_container_nodes.extend(make_blockage_diag_nodes(context))
+            if use_polar_voxel_outlier_filter:
+                shared_container_nodes.extend(make_polar_voxel_outlier_filter_node(context))
         case "cpu":
             lidar_specific_container_nodes.extend(make_preprocessor_nodes(context))
             lidar_specific_container_nodes.append(make_nebula_node(context, True))
-            list_preprocessor_uses = lidar_specific_container_nodes
 
             if use_blockage_diag:
                 lidar_specific_container_nodes.extend(make_blockage_diag_nodes(context))
+            if use_polar_voxel_outlier_filter:
+                lidar_specific_container_nodes.extend(make_polar_voxel_outlier_filter_node(context))
         case "cuda-with-cpu-concat":
             lidar_specific_container_nodes.extend(make_cuda_preprocessor_nodes(context))
             lidar_specific_container_nodes.append(make_nebula_node(context, True))
-            list_preprocessor_uses = lidar_specific_container_nodes
 
             if use_blockage_diag:
                 lidar_specific_container_nodes.extend(make_blockage_diag_nodes(context))
+            if use_polar_voxel_outlier_filter:
+                lidar_specific_container_nodes.extend(make_polar_voxel_outlier_filter_node(context))
         case _:
             raise ValueError(f"Unknown pipeline mode: {mode}")
-
-    # If used, insert polar_voxel_outlier_filter to the same list that nebula uses
-    match polar_voxel_outlier_filter_mode:
-        case "cpu" | "cuda":
-            lidar_specific_container_nodes.extend(make_polar_voxel_outlier_filter_node(context))
 
     launch_targets = [set_container_executable, set_container_mt_executable]
 

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -508,6 +508,9 @@ def launch_setup(context, *args, **kwargs):
     env = make_agnocast_env(context) if use_agnocast else {}
 
     use_blockage_diag = IfCondition(LaunchConfiguration("enable_blockage_diag")).evaluate(context)
+    polar_voxel_outlier_filter_mode = LaunchConfiguration(
+        "polar_voxel_visibility_estimation_mode"
+    ).perform(context)
 
     shared_container_nodes = []
     lidar_specific_container_nodes = []
@@ -567,8 +570,10 @@ def launch_setup(context, *args, **kwargs):
         case _:
             raise ValueError(f"Unknown pipeline mode: {mode}")
 
-    # insert polar_voxel_outlier_filter to the same list that pointcloud preprocessor uses
-    list_preprocessor_uses.extend(make_polar_voxel_outlier_filter_node(context))
+    # If used, insert polar_voxel_outlier_filter to the same list that nebula uses
+    match polar_voxel_outlier_filter_mode:
+        case "cpu" | "cuda":
+            lidar_specific_container_nodes.extend(make_polar_voxel_outlier_filter_node(context))
 
     launch_targets = [set_container_executable, set_container_mt_executable]
 

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -475,7 +475,7 @@ def make_polar_voxel_outlier_filter_node(context):
                         parameters,
                     ],
                     remappings=[
-                        ("input", "pointcloud_before_sync"),
+                        ("input", "pointcloud_raw_ex"),
                     ],
                     extra_arguments=[
                         {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
@@ -493,8 +493,8 @@ def make_polar_voxel_outlier_filter_node(context):
                         {"hardware_id": node_name},
                     ],
                     remappings=[
-                        ("~/input/pointcloud", "pointcloud_before_sync"),
-                        ("~/input/pointcloud/cuda", "pointcloud_before_sync/cuda"),
+                        ("~/input/pointcloud", "pointcloud_raw_ex"),
+                        ("~/input/pointcloud/cuda", "pointcloud_raw_ex"),
                     ],
                 )
             ]


### PR DESCRIPTION
### Summary

This PR addresses: https://tier4.atlassian.net/browse/T4DEV-12599
This pull request updates the input topic remappings for the polar voxel outlier filter node in the launch configuration. The changes ensure that the node now receives its input from the `pointcloud_raw_ex` topic instead of the previous `pointcloud_before_sync` topic.

**Remapping updates:**

* Changed the remapping of the `input` topic from `pointcloud_before_sync` to `pointcloud_raw_ex` in the `make_polar_voxel_outlier_filter_node` function.
* Updated the remappings for `~/input/pointcloud` and `~/input/pointcloud/cuda` to use `pointcloud_raw_ex` instead of `pointcloud_before_sync` in the same function.

### Known limitations

Because the input topic for visibility estimation is now on the raw pointcloud prior to distortion correction, at higher speeds visibility estimation may be impaired.

### Evaluation

The launcher changes were tested with X2 Gen2, with a sample from [this 30mm/h data]https://console.data-search.tier4.jp/projects/x2_dev/environments/e9e28650-5723-432b-828f-bab13e8a7fe1/rosbags/2f984be6-04c6-434a-b154-511b24a34737l) shown in operation below:
<img width="1826" height="1295" alt="image" src="https://github.com/user-attachments/assets/cacf040b-7f07-41ea-adb1-7737205e181a" />





