### PR TITLE
fix(aip_x2_gen2_launch): set max_tire_cut_angle for crop_box_filter_wheels

### DIFF
--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -100,10 +100,10 @@ def get_vehicle_info(context):
 
     wheel_width = gp["wheel_width"]
     wheel_radius = gp["wheel_radius"]
-    max_steer_angle_rad = gp["max_steer_angle"]
+    max_tire_cut_angle = 0.838
 
     max_lat_offset, max_lon_offset = get_max_extents_from_wheel_center(
-        wheel_width, wheel_radius, max_steer_angle_rad
+        wheel_width, wheel_radius, max_tire_cut_angle
     )
 
     p["wheels_min_longitudinal_offset"] = gp["wheel_base"] - max_lon_offset


### PR DESCRIPTION
タイヤ点群除去範囲を求めるのに最大ステア角ではなく最大タイヤ内切れ角を使う用にします。([slack link](https://star4.slack.com/archives/CRUE57C30/p1758171736092879?thread_ts=1756721492.492619&cid=CRUE57C30))
[タイヤ点群除去機能のPR](https://github.com/tier4/aip_launcher/pull/560)
こちらの修正で塩尻走行のタイヤ点群obstacle_stopが発生しなくなったのを確認しています。