### PR TITLE
chore(polar_voxel_outlier_filter): reduce threshold for secondary voxels for visibility estimation

### DIFF
--- a/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    publish_noise_cloud: false                             # Publish a separate point cloud containing detected noise points
+    publish_noise_cloud: false                            # Publish a separate point cloud containing detected noise points
     radial_resolution_m: 0.5                              # Voxel grid resolution in the radial (distance) direction, in meters
     azimuth_resolution_rad: 0.0175                        # Voxel grid resolution in the azimuth (horizontal angle) direction, in radians (~1 degree)
     elevation_resolution_rad: 0.0175                      # Voxel grid resolution in the elevation (vertical angle) direction, in radians (~1 degree)
@@ -8,7 +8,7 @@
     min_radius_m: 0.5                                     # Minimum distance from the sensor to include points, in meters
     max_radius_m: 300.0                                   # Maximum distance from the sensor to include points, in meters
     visibility_estimation_max_range_m: 10.0               # Maximum range for estimating point cloud visibility, in meters
-    visibility_estimation_max_secondary_voxel_count: 300  # Max number of secondary voxels to consider in visibility estimation
+    visibility_estimation_max_secondary_voxel_count: 200  # Max number of secondary voxels to consider in visibility estimation
     visibility_estimation_only: true                      # If true, only perform visibility estimation without filtering
     use_return_type_classification: true                  # Use return type information to classify points (e.g., primary/secondary returns)
     filter_secondary_returns: false                       # If true, filter out secondary returns and keep only primary returns


### PR DESCRIPTION
### Summary
This PR addresses: https://tier4.atlassian.net/browse/T4DEV-12599

This pull request makes a small adjustment to the configuration of the polar voxel outlier filter node. Specifically, it reduces the maximum number of secondary voxels considered during visibility estimation from 300 to 200, which may improve performance in fog conditions.

- Decreased the `visibility_estimation_max_secondary_voxel_count` parameter from 300 to 200 in `polar_voxel_outlier_filter_node.param.yaml` to limit the number of secondary voxels considered during visibility estimation.

### Known issues and limitations
While this parameter change increases the sensitivity of the visibility estimation, it also may cause visibility to reach zero in very severe conditions. While false positives in diagnostics should not be affected, lowered visibility from steam and exhaust pipes may increase.

### How to test
- Run in the perception evaluator and confirm that visibility tests are passed