### PR TITLE
feat: enable advanced functional safety mode in Nebula

### DIFF
--- a/aip_x2_gen2_launch/config/Pandar128E4X.param.yaml
+++ b/aip_x2_gen2_launch/config/Pandar128E4X.param.yaml
@@ -5,4 +5,13 @@
         mode: advanced
         error_definitions_path: $(find-pkg-share autoware_launch)/config/sensing/lidar/diagnostics/ot218_fusa_codes.csv
         ignored_error_codes:
-          - 0x1011 # Already ensured by SYNC.TOOLING
+        # Do not add descriptive comments here as long as AIP Launcher is public.
+        # Hesai's error descriptions and severity levels are confidential.
+          - 0x1011  # Already ensured by SYNC.TOOLING
+          - 0x0021
+          - 0x0622
+          - 0x0a13
+          - 0x0b23
+          - 0x0e11
+          - 0x0e22
+          - 0x1411

--- a/aip_x2_gen2_launch/config/Pandar128E4X.param.yaml
+++ b/aip_x2_gen2_launch/config/Pandar128E4X.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    diagnostics:
+      functional_safety:
+        mode: advanced
+        error_definitions_path: $(find-pkg-share autoware_launch)/config/sensing/lidar/diagnostics/ot218_fusa_codes.csv
+        ignored_error_codes:
+          - 0x1011 # Abnormal PTP Synchronization; Safety ensured by SYNC.TOOLING

--- a/aip_x2_gen2_launch/config/Pandar128E4X.param.yaml
+++ b/aip_x2_gen2_launch/config/Pandar128E4X.param.yaml
@@ -5,4 +5,4 @@
         mode: advanced
         error_definitions_path: $(find-pkg-share autoware_launch)/config/sensing/lidar/diagnostics/ot218_fusa_codes.csv
         ignored_error_codes:
-          - 0x1011 # Abnormal PTP Synchronization; Safety ensured by SYNC.TOOLING
+          - 0x1011 # Already ensured by SYNC.TOOLING

--- a/aip_x2_gen2_launch/config/PandarQT128.param.yaml
+++ b/aip_x2_gen2_launch/config/PandarQT128.param.yaml
@@ -6,4 +6,4 @@
         error_definitions_path: $(find-pkg-share autoware_launch)/config/sensing/lidar/diagnostics/qt128_fusa_codes.csv
         # In ROS 2, parameters cannot be an empty list, so this is commented out.
         # ignored_error_codes:
-        #  - 0xaaaa # description; justification
+        #  - 0xaaaa # justification

--- a/aip_x2_gen2_launch/config/PandarQT128.param.yaml
+++ b/aip_x2_gen2_launch/config/PandarQT128.param.yaml
@@ -1,0 +1,9 @@
+/**:
+  ros__parameters:
+    diagnostics:
+      functional_safety:
+        mode: advanced
+        error_definitions_path: $(find-pkg-share autoware_launch)/config/sensing/lidar/diagnostics/qt128_fusa_codes.csv
+        # In ROS 2, parameters cannot be an empty list, so this is commented out.
+        # ignored_error_codes:
+        #  - 0xaaaa # description; justification

--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -154,6 +154,10 @@ def make_nebula_node(context, as_composable_node, env=None):
             LaunchConfiguration("nebula_common_config_file").perform(context),
             allow_substs=True,
         ),
+        ParameterFile(
+            LaunchConfiguration("nebula_model_specific_config_file").perform(context),
+            allow_substs=True,
+        ),
         {
             "sensor_model": sensor_model,
             **create_parameter_dict(
@@ -630,6 +634,16 @@ def generate_launch_description():
             "/config/nebula_hesai_common.param.yaml",
         ],
         description="file containing parameters common to all Nebula instances",
+    )
+    add_launch_arg(
+        "nebula_model_specific_config_file",
+        [
+            FindPackageShare("aip_x2_gen2_launch"),
+            "/config/",
+            LaunchConfiguration("sensor_model"),
+            ".param.yaml",
+        ],
+        description="file containing parameters specific to the sensor model",
     )
     add_launch_arg("config_file", "", description="sensor configuration file")
     add_launch_arg("launch_hw", "true", "do launch driver")


### PR DESCRIPTION
Enable functional safety error code filtering in Nebula.

Related PRs:
* https://github.com/tier4/nebula/pull/363 -- Nebula feature
* https://github.com/tier4/autoware_launch.x2/pull/1652 -- error code definitions (confidential!)

For configuration details, see:
* https://github.com/tier4/nebula/pull/363
* the Hesai safety manuals in the Hesai Box drive (private)

Currently, only `0x1011` (a PTP related code) is exempted on OT128.
For the front and rear OT128, it seems that some codes related to laser health check are always reported. This is most likely due to the low mounting position.
For a list of commonly occuring codes, see:
* https://github.com/tier4/autoware_launch.x2/pull/1652