### PR TITLE
perf(hesai): add nebula buffer parameter

### DIFF
--- a/aip_xx1_gen2_launch/config/lidar_gen2.yaml
+++ b/aip_xx1_gen2_launch/config/lidar_gen2.yaml
@@ -8,6 +8,7 @@ launches:
       data_port: 2368
       sync_angle: 160
       cut_angle: 160.0
+      udp_socket_receive_buffer_size_bytes: 10800000
   - sensor_type: hesai_XT32
     namespace: front_left
     parameters:

--- a/aip_xx1_gen2_launch/config/lidar_gen2_1.yaml
+++ b/aip_xx1_gen2_launch/config/lidar_gen2_1.yaml
@@ -8,6 +8,7 @@ launches:
       data_port: 2368
       sync_angle: 180
       cut_angle: 180.0
+      udp_socket_receive_buffer_size_bytes: 10800000
   - sensor_type: hesai_XT32
     namespace: front_left
     parameters:

--- a/common_sensor_launch/launch/hesai_OT128.launch.xml
+++ b/common_sensor_launch/launch/hesai_OT128.launch.xml
@@ -16,6 +16,7 @@
   <arg name="vehicle_mirror_param_file"/>
   <arg name="container_name" default="hesai_node_container"/>
   <arg name="udp_only" default="false"/>
+  <arg name="udp_socket_receive_buffer_size_bytes" default="5400000"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/nebula_node_container.launch.py">
     <arg name="launch_driver" value="$(var launch_driver)"/>
@@ -40,5 +41,6 @@
     <arg name="ptp_lock_threshold" value="100"/>
     <arg name="setup_sensor" value="true"/>
     <arg name="udp_only" value="$(var udp_only)"/>
+    <arg name="udp_socket_receive_buffer_size_bytes" value="$(var udp_socket_receive_buffer_size_bytes)"/>
   </include>
 </launch>

--- a/common_sensor_launch/launch/hesai_XT32.launch.xml
+++ b/common_sensor_launch/launch/hesai_XT32.launch.xml
@@ -17,6 +17,7 @@
   <arg name="vehicle_mirror_param_file"/>
   <arg name="container_name" default="hesai_node_container"/>
   <arg name="udp_only" default="false"/>
+  <arg name="udp_socket_receive_buffer_size_bytes" default="5400000"/>
 
   <include file="$(find-pkg-share common_sensor_launch)/launch/nebula_node_container.launch.py">
     <arg name="launch_driver" value="$(var launch_driver)"/>
@@ -41,6 +42,7 @@
     <arg name="ptp_lock_threshold" value="100"/>
     <arg name="setup_sensor" value="true"/>
     <arg name="udp_only" value="$(var udp_only)"/>
+    <arg name="udp_socket_receive_buffer_size_bytes" value="$(var udp_socket_receive_buffer_size_bytes)"/>
     <arg name="retry_hw" value="true"/>
   </include>
 </launch>

--- a/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -152,6 +152,7 @@ def launch_setup(context, *args, **kwargs):
                         "ptp_switch_type",
                         "ptp_domain",
                         "diag_span",
+                        "udp_socket_receive_buffer_size_bytes",
                     ),
                 },
             ],
@@ -348,6 +349,11 @@ def generate_launch_description():
     add_launch_arg("vertical_bins", "128")
     add_launch_arg("is_channel_order_top2down", "true")
     add_launch_arg("horizontal_resolution", "0.4")
+    add_launch_arg(
+        "udp_socket_receive_buffer_size_bytes",
+        "5400000",
+        "Kernel UDP receive buffer size (SO_RCVBUF) in bytes for data socket",
+    )
     add_launch_arg(
         "blockage_diagnostics_param_file",
         os.path.join(


### PR DESCRIPTION
## Description

To prevent packet drops on OT128, we specify a large udp_socket_receive_buffer.

In https://github.com/tier4/nebula/pull/365, new parameter `udp_socket_receive_buffer_size_bytes` is introduced. So we can specify the desired buffer length. Since the parameter does not have the default value, we need to specify the value.

In this PR we specifies 10'800'000 for OT128 and 5'400'000 for XT32.
Before the nebula update, 5'400'000 is used for both OT128 and XT32.

This change does not affect X2 and X1. Because X2 has the own [nebula_node_container](https://github.com/tier4/aip_launcher/blob/tier4/universe/aip_x2_gen2_launch/launch/nebula_node_container.launch.py), and X1 does not use [OT128](https://github.com/tier4/aip_launcher/blob/5c3caad00301bd1d72c1c31b11eb076c4c00971e/aip_x1_launch/launch/lidar.launch.xml).

> [!NOTE]
> When we use the combination of this PR and **old nebula**, the new parameter `udp_socket_receive_buffer_size_bytes`  will be just ignored. So the lidar will work as before.

## Note

```
10800000 = 3600 x 1500 x 2
5400000 = 3600 x 1500
```

* 1500: expected packet size of LiDAR UDP
* 3600: UDP queue size (= 1 scan's worth of packets on OT128)

Please see the nebula PR for more details 

## How did this PR tested.

I have checked that the specified parameter is loaded correctly by nebula.

<img width="1465" height="448" alt="image" src="https://github.com/user-attachments/assets/d044cbe1-ed15-4892-97a6-7ad547ffc673" />



## Related Links
* [TIER IV INTERNAL JIRA ticket](https://tier4.atlassian.net/browse/T4DEV-33804)
* [TIER IV INTERNAL Confluence](https://tier4.atlassian.net/wiki/spaces/XFST/pages/4224286841/UDP+Receive+Buffer+Error)
