### PR TITLE
fix(xx1): add concat diag for XX1 gen1

### DIFF
--- a/aip_xx1_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_xx1_gen2_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -33,7 +33,7 @@
       "topic_state_monitor_camera10: sensing_topic_status": default
 
       #lidar
-      "concatenate_data: concat_status": default
+      "concatenate_data: /sensing/lidar/concatenate_data": default
 
       "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_status": default
       "/sensing/lidar/side_left/hesai_ros_wrapper_node: hesai_ptp": default

--- a/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
+++ b/aip_xx1_launch/config/dummy_diag_publisher/sensor_kit.param.yaml
@@ -15,6 +15,9 @@
       # performance monitoring  ----> To be confirmed in v0.47.0
       # "blockage: blockage_validation": default
 
+      # lidar
+      "concatenate_data: /sensing/lidar/concatenate_data": default
+
       # velodyne
       "/sensing/lidar/top/velodyne_ros_wrapper_node: velodyne_status": default
       "/sensing/lidar/top/velodyne_ros_wrapper_node: velodyne_temperature": default


### PR DESCRIPTION
## Description:

XX1 gen1 will check the lidar concatenation diagnostics. So i added the dummy diagnostics for planning_simulator

* related PR: https://github.com/tier4/autoware_launch.xx1/pull/1674


## How does it tested

Here is the evidence of diagnostics name.

<img width="1649" height="903" alt="image" src="https://github.com/user-attachments/assets/7a8e0c8f-b1c4-49b0-890d-ea1e7835ca31" />
