### PR TITLE
chore: fix concat timeout to avoid performance issue

### DIFF
--- a/aip_x2_gen2_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/aip_x2_gen2_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -4,7 +4,7 @@
     has_static_tf_only: false
     rosbag_length: 10.0
     maximum_queue_size: 5
-    timeout_sec: 0.2
+    timeout_sec: 0.09 # under 0.1 sec to avoid waiting for next lidar frame
     is_motion_compensated: true
     publish_synchronized_pointcloud: true
     keep_input_frame_in_synchronized_pointcloud: true


### PR DESCRIPTION
According to [TIER IV internal discussion](https://star4.slack.com/archives/C04MG7VELKV/p1761279777957089?thread_ts=1760918428.203899&cid=C04MG7VELKV), longer concat timeout could consume more memory so it is better to set this value under 100ms.

@drwnz @vividf 
How do you think about it?