### PR TITLE
feat(aip_x2_gen2_launch): add new parameters for polar_voxel_outlier_fitler

### DIFF
--- a/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
@@ -8,6 +8,10 @@
     min_radius_m: 0.5                                     # Minimum distance from the sensor to include points, in meters
     max_radius_m: 300.0                                   # Maximum distance from the sensor to include points, in meters
     visibility_estimation_max_range_m: 10.0               # Maximum range for estimating point cloud visibility, in meters
+    visibility_estimation_min_azimuth_rad: 0.78           # Minimum azimuth for estimating point cloud visibility, in radius
+    visibility_estimation_max_azimuth_rad: 2.35           # Maximum azimuth for estimating point cloud visibility, in radius
+    visibility_estimation_min_elevation_rad: -0.26        # Minimum elevation for estimating point cloud visibility, in radius
+    visibility_estimation_max_elevation_rad: 1.04         # Maximum elevation for estimating point cloud visibility, in radius
     visibility_estimation_max_secondary_voxel_count: 200  # Max number of secondary voxels to consider in visibility estimation
     visibility_estimation_only: true                      # If true, only perform visibility estimation without filtering
     use_return_type_classification: true                  # Use return type information to classify points (e.g., primary/secondary returns)
@@ -19,3 +23,7 @@
     filter_ratio_error_threshold: 0.5                     # Error threshold for filter ratio diagnostics
     filter_ratio_warn_threshold: 0.7                      # Warning threshold for filter ratio diagnostics
     visibility_error_threshold: 0.8                       # Error threshold for visibility diagnostics
+    num_frames_hysteresis_transition: 1                   # The number of frames to be required to transition judgement
+    immediate_report_error: false                         # Whether to report error state immediately if a single frame categorized as error
+    immediate_relax_state: false                          # Whether to relax state if observed state is better than the current one
+    publish_area_marker: false                            # Publish a marker to visualize region used for visibility estimation


### PR DESCRIPTION
This PR udpates the `aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml` to  limit the area used for visibility estimation

related links:
- PR to awf/universe: https://github.com/autowarefoundation/autoware_universe/pull/11549
- PR to tier4/universe: https://github.com/tier4/autoware_universe/pull/2472