### PR TITLE
fix(aip_x2_gen2_launch/nebula_hesai_common.param.yaml): set hysteresis to LiDAR rate bounds

### DIFF
--- a/aip_x2_gen2_launch/config/nebula_hesai_common.param.yaml
+++ b/aip_x2_gen2_launch/config/nebula_hesai_common.param.yaml
@@ -11,5 +11,6 @@
           min_hz: 9.5
         frequency_warn:
           min_hz: 8.0
+        num_frame_transition: 5
     sync_diagnostics:
       topic: /sync_diag/graph_updates


### PR DESCRIPTION
This PR introduces a hysteresis on the diag-sender side (i.e., Nebula) by considering topic drops on the diag-receiver side. 
To avoid duplication, the hysteresis of the receiver side is going to be disabled by 
- https://github.com/tier4/autoware_launch.x2/pull/1696