### PR TITLE
fix(aip_x2_gen2_launch/nebula_hesai_common.param.yaml): manual backport of #616 (set hysteresis to LiDAR rate bounds)

### DIFF
--- a/aip_x2_gen2_launch/config/nebula_hesai_common.param.yaml
+++ b/aip_x2_gen2_launch/config/nebula_hesai_common.param.yaml
@@ -11,7 +11,7 @@
           min_hz: 9.5
           max_hz: 10.5
         frequency_warn:
-          min_hz: 9.0
-          max_hz: 11.0
+          min_hz: 8.0
+        num_frame_transition: 5
     sync_diagnostics:
       topic: /sync_diag/graph_updates


### PR DESCRIPTION

(cherry picked from commit c4dcb88efddcc290457a487d1e14b6a3bf650346)