### PR TITLE
chore(xx1_gen2): port #614, #603, #616, #601, #621

### DIFF
--- a/aip_common_sensor_launch/config/nebula_hesai_common.param.yaml
+++ b/aip_common_sensor_launch/config/nebula_hesai_common.param.yaml
@@ -5,13 +5,13 @@
     ptp_transport_type: L2
     ptp_switch_type: NON_TSN
     ptp_lock_threshold: 100
+    enable_calibration_download: true
     diagnostics:
       pointcloud_publish_rate:
         frequency_ok:
           min_hz: 9.5
-          max_hz: 10.5
         frequency_warn:
-          min_hz: 9.0
-          max_hz: 11.0
+          min_hz: 8.0
+        num_frame_transition: 5
     sync_diagnostics:
       topic: /sync_diag/graph_updates

--- a/aip_common_sensor_launch/launch/hesai_OT128.launch.xml
+++ b/aip_common_sensor_launch/launch/hesai_OT128.launch.xml
@@ -9,6 +9,7 @@
   <arg name="sensor_ip" default="192.168.1.201"/>
   <arg name="host_ip" default="255.255.255.255"/>
   <arg name="data_port" default="2368"/>
+  <arg name="udp_socket_receive_buffer_size_bytes" default="10800000"/>
   <arg name="scan_phase" default="0.0"/>
   <arg name="cloud_min_angle" default="0"/>
   <arg name="cloud_max_angle" default="360"/>
@@ -28,6 +29,7 @@
     <arg name="sensor_ip" value="$(var sensor_ip)"/>
     <arg name="host_ip" value="$(var host_ip)"/>
     <arg name="data_port" value="$(var data_port)"/>
+    <arg name="udp_socket_receive_buffer_size_bytes" value="$(var udp_socket_receive_buffer_size_bytes)"/>
     <arg name="scan_phase" value="$(var scan_phase)"/>
     <arg name="cloud_min_angle" value="$(var cloud_min_angle)"/>
     <arg name="cloud_max_angle" value="$(var cloud_max_angle)"/>

--- a/aip_common_sensor_launch/launch/hesai_XT32.launch.xml
+++ b/aip_common_sensor_launch/launch/hesai_XT32.launch.xml
@@ -9,6 +9,7 @@
   <arg name="sensor_ip" default="192.168.1.201"/>
   <arg name="host_ip" default="255.255.255.255"/>
   <arg name="data_port" default="2368"/>
+  <arg name="udp_socket_receive_buffer_size_bytes" default="5400000"/>
   <arg name="scan_phase" default="0.0"/>
   <arg name="cloud_min_angle" default="0"/>
   <arg name="cloud_max_angle" default="360"/>
@@ -28,6 +29,7 @@
     <arg name="sensor_ip" value="$(var sensor_ip)"/>
     <arg name="host_ip" value="$(var host_ip)"/>
     <arg name="data_port" value="$(var data_port)"/>
+    <arg name="udp_socket_receive_buffer_size_bytes" value="$(var udp_socket_receive_buffer_size_bytes)"/>
     <arg name="scan_phase" value="$(var scan_phase)"/>
     <arg name="cloud_min_angle" value="$(var cloud_min_angle)"/>
     <arg name="cloud_max_angle" value="$(var cloud_max_angle)"/>

--- a/aip_common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/aip_common_sensor_launch/launch/nebula_node_container.launch.py
@@ -117,6 +117,7 @@ def make_nebula_nodes(context):
                     "calibration_file": sensor_calib_fp,
                     "sensor_model": sensor_model,
                     "launch_hw": LaunchConfiguration("launch_driver"),
+                    "calibration_download_enabled": True,
                     **create_parameter_dict(
                         "host_ip",
                         "sensor_ip",
@@ -142,6 +143,7 @@ def make_nebula_nodes(context):
                         "hires_mode",
                         "diag_span",
                         "diagnostics.packet_loss.error_threshold",
+                        "udp_socket_receive_buffer_size_bytes",
                     ),
                 },
             ],
@@ -414,6 +416,7 @@ def generate_launch_description():
     add_launch_arg("launch_driver", "True", "do launch driver")
     add_launch_arg("setup_sensor", "True", "configure sensor")
     add_launch_arg("udp_only", "False", "use UDP only")
+    add_launch_arg("udp_socket_receive_buffer_size_bytes", "5400000", "UDP socket receive buffer size in bytes")
     add_launch_arg("retry_hw", "false", "retry hw")
     add_launch_arg("sensor_ip", "192.168.1.201", "device ip address")
     add_launch_arg(

--- a/aip_common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/aip_common_sensor_launch/launch/nebula_node_container.launch.py
@@ -416,7 +416,9 @@ def generate_launch_description():
     add_launch_arg("launch_driver", "True", "do launch driver")
     add_launch_arg("setup_sensor", "True", "configure sensor")
     add_launch_arg("udp_only", "False", "use UDP only")
-    add_launch_arg("udp_socket_receive_buffer_size_bytes", "5400000", "UDP socket receive buffer size in bytes")
+    add_launch_arg(
+        "udp_socket_receive_buffer_size_bytes", "5400000", "UDP socket receive buffer size in bytes"
+    )
     add_launch_arg("retry_hw", "false", "retry hw")
     add_launch_arg("sensor_ip", "192.168.1.201", "device ip address")
     add_launch_arg(

--- a/aip_xx1_gen2_launch/config/ARS548.param.yaml
+++ b/aip_xx1_gen2_launch/config/ARS548.param.yaml
@@ -24,12 +24,14 @@
         test_level:
           ok: 1
           warn: 1
+        num_frame_transition: 5
+      internal:
+        num_frame_transition: 10
       rate_bound_status:
         frequency_ok:
           min_hz: 9.0
-          max_hz: 11.0
         frequency_warn:
           min_hz: 8.0
-          max_hz: 12.0
+        num_frame_transition: 3
     sync_diagnostics:
       topic: /sync_diag/graph_updates


### PR DESCRIPTION
Port
- #614
- #603
- #616
- #601
- #621
from X2 gen2 to XX1 gen2. The changes exclusively affect Hesai sensors and ARS548, so XX1 gen1 is unaffected.

As for the changes in #603, the advanced functional safety filter feature has been left off (same as the previous behavior) in this PR, as I do not know about the MRM requirements of XX1.

As for #621, it is a fix to a problem specific to OT128 LiDARs, that only occurred on X2 gen2 so far (multiple OT128s overlapping and having different distortion at far distances). I am confident it is not needed for XX1 gen2, so I set the new parameter `enable_calibration_download` to `true`, which is equal to the previous behavior.