### PR TITLE
fix(aip_xx1_gen2_launch): remove 1 line to pass pre-commit

### DIFF
--- a/aip_xx1_gen2_launch/launch/pointcloud_preprocessor.launch.py
+++ b/aip_xx1_gen2_launch/launch/pointcloud_preprocessor.launch.py
@@ -25,7 +25,6 @@ from launch.substitutions import EnvironmentVariable
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
-from launch_ros.parameter_descriptions import ParameterFile
 import yaml
 
 


### PR DESCRIPTION
## Description

In https://github.com/tier4/aip_launcher/pull/624 , I realized pre-commit ci is failing. So I fixed it.
https://results.pre-commit.ci/run/github/405717191/1761818239.HSEmhglfTV2D2GCyf4holA

<img width="1282" height="255" alt="image" src="https://github.com/user-attachments/assets/6ffed5d6-ef87-4999-8bd4-4894a5fb3f99" />


## How was this PR tested

now, pre-commit is OK.

<img width="1244" height="840" alt="image" src="https://github.com/user-attachments/assets/0cc6f860-43fb-45a3-b3f9-f0d31ba19818" />
