### PR TITLE
fix(aip_x2_gen2_launch): remove unused radar_objects_adapter nodes and use component container for throttle in radar.launch

### DIFF
--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -11,9 +11,27 @@
   <let name="acceleration_throttled_topic" value="$(var acceleration_topic)_throttled"/>
   <let name="steering_angle_throttled_topic" value="$(var steering_angle_topic)_throttled"/>
 
-  <node pkg="topic_tools" exec="throttle" name="odometry_throttler" output="screen" args="messages $(var odometry_topic) 25.0 $(var odometry_throttled_topic)"/>
-  <node pkg="topic_tools" exec="throttle" name="acceleration_throttler" output="screen" args="messages $(var acceleration_topic) 25.0 $(var acceleration_throttled_topic)"/>
-  <node pkg="topic_tools" exec="throttle" name="steering_angle_throttler" output="screen" args="messages $(var steering_angle_topic) 25.0 $(var steering_angle_throttled_topic)"/>
+  <!-- Component container for throttle nodes -->
+  <node_container pkg="rclcpp_components" exec="component_container" name="throttle_container" namespace="" output="screen">
+    <composable_node pkg="topic_tools" plugin="topic_tools::ThrottleNode" name="odometry_throttler">
+      <param name="input_topic" value="$(var odometry_topic)"/>
+      <param name="output_topic" value="$(var odometry_throttled_topic)"/>
+      <param name="throttle_type" value="messages"/>
+      <param name="msgs_per_sec" value="25.0"/>
+    </composable_node>
+    <composable_node pkg="topic_tools" plugin="topic_tools::ThrottleNode" name="acceleration_throttler">
+      <param name="input_topic" value="$(var acceleration_topic)"/>
+      <param name="output_topic" value="$(var acceleration_throttled_topic)"/>
+      <param name="throttle_type" value="messages"/>
+      <param name="msgs_per_sec" value="25.0"/>
+    </composable_node>
+    <composable_node pkg="topic_tools" plugin="topic_tools::ThrottleNode" name="steering_angle_throttler">
+      <param name="input_topic" value="$(var steering_angle_topic)"/>
+      <param name="output_topic" value="$(var steering_angle_throttled_topic)"/>
+      <param name="throttle_type" value="messages"/>
+      <param name="msgs_per_sec" value="25.0"/>
+    </composable_node>
+  </node_container>
 
   <group>
     <push-ros-namespace namespace="radar"/>

--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -67,14 +67,6 @@
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
       </include>
-
-      <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-        <arg name="input_radar_objects" value="radar_objects"/>
-        <arg name="input_radar_info" value="radar_info"/>
-        <arg name="output_detections" value="detected_objects"/>
-        <arg name="output_tracks" value="tracked_objects"/>
-        <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-      </include>
     </group>
 
     <group>
@@ -95,14 +87,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-      </include>
-
-      <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-        <arg name="input_radar_objects" value="radar_objects"/>
-        <arg name="input_radar_info" value="radar_info"/>
-        <arg name="output_detections" value="detected_objects"/>
-        <arg name="output_tracks" value="tracked_objects"/>
-        <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
       </include>
     </group>
 
@@ -154,14 +138,6 @@
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
       </include>
-
-      <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-        <arg name="input_radar_objects" value="radar_objects"/>
-        <arg name="input_radar_info" value="radar_info"/>
-        <arg name="output_detections" value="detected_objects"/>
-        <arg name="output_tracks" value="tracked_objects"/>
-        <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-      </include>
     </group>
 
     <group>
@@ -182,14 +158,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-      </include>
-
-      <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-        <arg name="input_radar_objects" value="radar_objects"/>
-        <arg name="input_radar_info" value="radar_info"/>
-        <arg name="output_detections" value="detected_objects"/>
-        <arg name="output_tracks" value="tracked_objects"/>
-        <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
       </include>
     </group>
 


### PR DESCRIPTION
## Background
One cause of Pilot.Auto's long startup time is the exponential increase in discovery traffic due to the large number of ROS2 processes.
We are working to address this by reducing the process count through loading nodes into component containers.
https://star4.slack.com/archives/CTEJP8L4T/p1761906077877939

## Changes
- Unused adapter nodes are removed
- Throttle nodes are launched in component container to reduce process.

## Test
The following script was run, and its output was compared before and after the change.

```sh
#!/usr/bin/env bash

echo "Starting to fetch info for active ROS 2 nodes..."
echo

for node in $(ros2 node list)
do
    if [[ "$node" == *transform_listener* ]]; then
        continue
    fi
    if [[ "$node" == *launch_ros* ]]; then
        continue

    echo "##################################################"
    echo "## Node Info: $node"
    echo "##################################################"

    ros2 node info "$node"
    
    echo 
done

echo "All node info retrieved."
```

The result shows that the 4 nodes are removed, throttle container is added and other nodes and topics are not changed.

```
$ colordiff -u x2_v4_3_commit14_api_container2.txt x2_v4_3_commit15_radar3.txt 
--- x2_v4_3_commit14_api_container2.txt	2025-11-10 16:07:27.620027667 +0900
+++ x2_v4_3_commit15_radar3.txt	2025-11-10 16:38:50.089425479 +0900

@@ -7131,34 +7131,6 @@
 
 
 ##################################################
-## Node Info: /sensing/radar/front_left/radar_objects_adapter
-##################################################
-/sensing/radar/front_left/radar_objects_adapter
-  Subscribers:
-    /clock: rosgraph_msgs/msg/Clock
-    /parameter_events: rcl_interfaces/msg/ParameterEvent
-    /sensing/radar/front_left/radar_info: autoware_sensing_msgs/msg/RadarInfo
-    /sensing/radar/front_left/radar_objects: autoware_sensing_msgs/msg/RadarObjects
-  Publishers:
-    /parameter_events: rcl_interfaces/msg/ParameterEvent
-    /rosout: rcl_interfaces/msg/Log
-    /sensing/radar/front_left/detected_objects: autoware_perception_msgs/msg/DetectedObjects
-    /sensing/radar/front_left/tracked_objects: autoware_perception_msgs/msg/TrackedObjects
-  Service Servers:
-    /sensing/radar/front_left/radar_objects_adapter/describe_parameters: rcl_interfaces/srv/DescribeParameters
-    /sensing/radar/front_left/radar_objects_adapter/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
-    /sensing/radar/front_left/radar_objects_adapter/get_parameters: rcl_interfaces/srv/GetParameters
-    /sensing/radar/front_left/radar_objects_adapter/list_parameters: rcl_interfaces/srv/ListParameters
-    /sensing/radar/front_left/radar_objects_adapter/set_parameters: rcl_interfaces/srv/SetParameters
-    /sensing/radar/front_left/radar_objects_adapter/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
-  Service Clients:
-
-  Action Servers:
-
-  Action Clients:
-
-
-##################################################
 ## Node Info: /sensing/radar/front_right/nebula_continental_ars548
 ##################################################
 /sensing/radar/front_right/nebula_continental_ars548
@@ -7195,52 +7167,6 @@
 
 
 ##################################################
-## Node Info: /sensing/radar/front_right/radar_objects_adapter
-##################################################
-/sensing/radar/front_right/radar_objects_adapter
-  Subscribers:
-    /clock: rosgraph_msgs/msg/Clock
-    /parameter_events: rcl_interfaces/msg/ParameterEvent
-    /sensing/radar/front_right/radar_info: autoware_sensing_msgs/msg/RadarInfo
-    /sensing/radar/front_right/radar_objects: autoware_sensing_msgs/msg/RadarObjects
-  Publishers:
-    /parameter_events: rcl_interfaces/msg/ParameterEvent
-    /rosout: rcl_interfaces/msg/Log
-    /sensing/radar/front_right/detected_objects: autoware_perception_msgs/msg/DetectedObjects
-    /sensing/radar/front_right/tracked_objects: autoware_perception_msgs/msg/TrackedObjects
-  Service Servers:
-    /sensing/radar/front_right/radar_objects_adapter/describe_parameters: rcl_interfaces/srv/DescribeParameters
-    /sensing/radar/front_right/radar_objects_adapter/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
-    /sensing/radar/front_right/radar_objects_adapter/get_parameters: rcl_interfaces/srv/GetParameters
-    /sensing/radar/front_right/radar_objects_adapter/list_parameters: rcl_interfaces/srv/ListParameters
-    /sensing/radar/front_right/radar_objects_adapter/set_parameters: rcl_interfaces/srv/SetParameters
-    /sensing/radar/front_right/radar_objects_adapter/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
-  Service Clients:
-
-  Action Servers:
-
-  Action Clients:
-
-
-##################################################
-## Node Info: /sensing/radar/radar_container
-##################################################
-/sensing/radar/radar_container
-  Subscribers:
-    /clock: rosgraph_msgs/msg/Clock
-    /parameter_events: rcl_interfaces/msg/ParameterEvent
-  Publishers:
-    /rosout: rcl_interfaces/msg/Log
-  Service Servers:
-
-  Service Clients:
-
-  Action Servers:
-
-  Action Clients:
-
-
-##################################################
 ## Node Info: /sensing/radar/rear_center/nebula_continental_ars548
 ##################################################
 /sensing/radar/rear_center/nebula_continental_ars548
@@ -7341,34 +7267,6 @@
 
 
 ##################################################
-## Node Info: /sensing/radar/rear_left/radar_objects_adapter
-##################################################
-/sensing/radar/rear_left/radar_objects_adapter
-  Subscribers:
-    /clock: rosgraph_msgs/msg/Clock
-    /parameter_events: rcl_interfaces/msg/ParameterEvent
-    /sensing/radar/rear_left/radar_info: autoware_sensing_msgs/msg/RadarInfo
-    /sensing/radar/rear_left/radar_objects: autoware_sensing_msgs/msg/RadarObjects
-  Publishers:
-    /parameter_events: rcl_interfaces/msg/ParameterEvent
-    /rosout: rcl_interfaces/msg/Log
-    /sensing/radar/rear_left/detected_objects: autoware_perception_msgs/msg/DetectedObjects
-    /sensing/radar/rear_left/tracked_objects: autoware_perception_msgs/msg/TrackedObjects
-  Service Servers:
-    /sensing/radar/rear_left/radar_objects_adapter/describe_parameters: rcl_interfaces/srv/DescribeParameters
-    /sensing/radar/rear_left/radar_objects_adapter/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
-    /sensing/radar/rear_left/radar_objects_adapter/get_parameters: rcl_interfaces/srv/GetParameters
-    /sensing/radar/rear_left/radar_objects_adapter/list_parameters: rcl_interfaces/srv/ListParameters
-    /sensing/radar/rear_left/radar_objects_adapter/set_parameters: rcl_interfaces/srv/SetParameters
-    /sensing/radar/rear_left/radar_objects_adapter/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
-  Service Clients:
-
-  Action Servers:
-
-  Action Clients:
-
-
-##################################################
 ## Node Info: /sensing/radar/rear_right/nebula_continental_ars548
 ##################################################
 /sensing/radar/rear_right/nebula_continental_ars548
@@ -7405,34 +7303,6 @@
 
 
 ##################################################
-## Node Info: /sensing/radar/rear_right/radar_objects_adapter
-##################################################
-/sensing/radar/rear_right/radar_objects_adapter
-  Subscribers:
-    /clock: rosgraph_msgs/msg/Clock
-    /parameter_events: rcl_interfaces/msg/ParameterEvent
-    /sensing/radar/rear_right/radar_info: autoware_sensing_msgs/msg/RadarInfo
-    /sensing/radar/rear_right/radar_objects: autoware_sensing_msgs/msg/RadarObjects
-  Publishers:
-    /parameter_events: rcl_interfaces/msg/ParameterEvent
-    /rosout: rcl_interfaces/msg/Log
-    /sensing/radar/rear_right/detected_objects: autoware_perception_msgs/msg/DetectedObjects
-    /sensing/radar/rear_right/tracked_objects: autoware_perception_msgs/msg/TrackedObjects
-  Service Servers:
-    /sensing/radar/rear_right/radar_objects_adapter/describe_parameters: rcl_interfaces/srv/DescribeParameters
-    /sensing/radar/rear_right/radar_objects_adapter/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
-    /sensing/radar/rear_right/radar_objects_adapter/get_parameters: rcl_interfaces/srv/GetParameters
-    /sensing/radar/rear_right/radar_objects_adapter/list_parameters: rcl_interfaces/srv/ListParameters
-    /sensing/radar/rear_right/radar_objects_adapter/set_parameters: rcl_interfaces/srv/SetParameters
-    /sensing/radar/rear_right/radar_objects_adapter/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
-  Service Clients:
-
-  Action Servers:
-
-  Action Clients:
-
-
-##################################################
 ## Node Info: /sensing/radar/simple_object_merger
 ##################################################
 /sensing/radar/simple_object_merger
@@ -7533,6 +7403,24 @@
   Service Clients:
 
   Action Servers:
+
+  Action Clients:
+
+
+##################################################
+## Node Info: /sensing/throttle_container
+##################################################
+/sensing/throttle_container
+  Subscribers:
+    /clock: rosgraph_msgs/msg/Clock
+    /parameter_events: rcl_interfaces/msg/ParameterEvent
+  Publishers:
+    /rosout: rcl_interfaces/msg/Log
+  Service Servers:
+
+  Service Clients:
+
+  Action Servers:
 
   Action Clients:
```