### PR TITLE
shorten left_lower lidar range: Centerpoint left-side lost issue temporal measure

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -197,7 +197,7 @@
         <arg name="cloud_max_angle" value="270"/>
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.1"/>
-        <arg name="max_range" value="50.0"/>
+        <arg name="max_range" value="12.0"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>


### PR DESCRIPTION
- This PR is temporal measure for objects (pedestrian) lost in centerpoint in the left-side region.
  - [JIRA Ticket](https://tier4.atlassian.net/browse/T4DEV-40981)
- Compare before-after change：

| | Before | After | 
|--- |---| ---|
|Evaluation test | [reference_for_shorten_left_lower](https://evaluation.tier4.jp/evaluation/reports/cd32d24b-778a-5286-ba7c-4d19abf76984?project_id=x2_dev) | [exp/shorten_left_lower](https://evaluation.tier4.jp/evaluation/reports/e13e8da2-72dc-50b6-b257-9d5862c04bdd?project_id=x2_dev) |
| Concat Pointcloud | <img width="1834" height="1072" alt="image" src="https://github.com/user-attachments/assets/7b78e46b-2674-4aae-8255-6c5c3891a16c" /> | <img width="1834" height="1072" alt="image" src="https://github.com/user-attachments/assets/d1844b9b-0062-405b-b931-283e2e4a3b6c" />|
| Left_lower pointcloud| <img width="1440" height="842" alt="image" src="https://github.com/user-attachments/assets/b9c264fa-136c-4464-8585-1008bc9e1a8a" /> |<img width="1440" height="842" alt="image" src="https://github.com/user-attachments/assets/73a7390a-8fce-4a2e-8e75-082fc0c77a37" />|

- concatenated/pointcloud become a little sparser inside the red line: 
<img width="1440" height="810" alt="image" src="https://github.com/user-attachments/assets/d8c5184d-a1cf-444c-836d-94487a054092" />


