### PR TITLE
fix(aip_x2_gen2_launch): backport #635 to v0.48

### DIFF
--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -11,9 +11,27 @@
   <let name="acceleration_throttled_topic" value="$(var acceleration_topic)_throttled"/>
   <let name="steering_angle_throttled_topic" value="$(var steering_angle_topic)_throttled"/>
 
-  <node pkg="topic_tools" exec="throttle" name="odometry_throttler" output="screen" args="messages $(var odometry_topic) 25.0 $(var odometry_throttled_topic)"/>
-  <node pkg="topic_tools" exec="throttle" name="acceleration_throttler" output="screen" args="messages $(var acceleration_topic) 25.0 $(var acceleration_throttled_topic)"/>
-  <node pkg="topic_tools" exec="throttle" name="steering_angle_throttler" output="screen" args="messages $(var steering_angle_topic) 25.0 $(var steering_angle_throttled_topic)"/>
+  <!-- Component container for throttle nodes -->
+  <node_container pkg="rclcpp_components" exec="component_container" name="throttle_container" namespace="" output="screen">
+    <composable_node pkg="topic_tools" plugin="topic_tools::ThrottleNode" name="odometry_throttler">
+      <param name="input_topic" value="$(var odometry_topic)"/>
+      <param name="output_topic" value="$(var odometry_throttled_topic)"/>
+      <param name="throttle_type" value="messages"/>
+      <param name="msgs_per_sec" value="25.0"/>
+    </composable_node>
+    <composable_node pkg="topic_tools" plugin="topic_tools::ThrottleNode" name="acceleration_throttler">
+      <param name="input_topic" value="$(var acceleration_topic)"/>
+      <param name="output_topic" value="$(var acceleration_throttled_topic)"/>
+      <param name="throttle_type" value="messages"/>
+      <param name="msgs_per_sec" value="25.0"/>
+    </composable_node>
+    <composable_node pkg="topic_tools" plugin="topic_tools::ThrottleNode" name="steering_angle_throttler">
+      <param name="input_topic" value="$(var steering_angle_topic)"/>
+      <param name="output_topic" value="$(var steering_angle_throttled_topic)"/>
+      <param name="throttle_type" value="messages"/>
+      <param name="msgs_per_sec" value="25.0"/>
+    </composable_node>
+  </node_container>
 
   <group>
     <push-ros-namespace namespace="radar"/>
@@ -67,14 +85,6 @@
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
       </include>
-
-      <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-        <arg name="input_radar_objects" value="radar_objects"/>
-        <arg name="input_radar_info" value="radar_info"/>
-        <arg name="output_detections" value="detected_objects"/>
-        <arg name="output_tracks" value="tracked_objects"/>
-        <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-      </include>
     </group>
 
     <group>
@@ -95,14 +105,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-      </include>
-
-      <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-        <arg name="input_radar_objects" value="radar_objects"/>
-        <arg name="input_radar_info" value="radar_info"/>
-        <arg name="output_detections" value="detected_objects"/>
-        <arg name="output_tracks" value="tracked_objects"/>
-        <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
       </include>
     </group>
 
@@ -154,14 +156,6 @@
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
       </include>
-
-      <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-        <arg name="input_radar_objects" value="radar_objects"/>
-        <arg name="input_radar_info" value="radar_info"/>
-        <arg name="output_detections" value="detected_objects"/>
-        <arg name="output_tracks" value="tracked_objects"/>
-        <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-      </include>
     </group>
 
     <group>
@@ -182,14 +176,6 @@
         <arg name="data_port" value="42102"/>
         <arg name="configuration_host_port" value="42401"/>
         <arg name="configuration_sensor_port" value="42101"/>
-      </include>
-
-      <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-        <arg name="input_radar_objects" value="radar_objects"/>
-        <arg name="input_radar_info" value="radar_info"/>
-        <arg name="output_detections" value="detected_objects"/>
-        <arg name="output_tracks" value="tracked_objects"/>
-        <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
       </include>
     </group>
 


### PR DESCRIPTION
Backport https://github.com/tier4/aip_launcher/commit/626b08428d3a552d91f82cc6d7d0a18e6462979e from https://github.com/tier4/aip_launcher/pull/635.