### PR TITLE
per(aip_xx1_gen2_launch): remove unused radar_objects_adapter nodes and use component container for throttle in radar.launch 

### DIFF
--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -63,15 +63,6 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-
-        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-          <arg name="input_radar_objects" value="radar_objects"/>
-          <arg name="input_radar_info" value="radar_info"/>
-          <arg name="output_detections" value="detected_objects"/>
-          <arg name="output_tracks" value="tracked_objects"/>
-          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-        </include>
-
       </group>
     </group>
 
@@ -96,15 +87,6 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-
-        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-          <arg name="input_radar_objects" value="radar_objects"/>
-          <arg name="input_radar_info" value="radar_info"/>
-          <arg name="output_detections" value="detected_objects"/>
-          <arg name="output_tracks" value="tracked_objects"/>
-          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-        </include>
-
       </group>
     </group>
 
@@ -129,15 +111,6 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-
-        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-          <arg name="input_radar_objects" value="radar_objects"/>
-          <arg name="input_radar_info" value="radar_info"/>
-          <arg name="output_detections" value="detected_objects"/>
-          <arg name="output_tracks" value="tracked_objects"/>
-          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-        </include>
-
       </group>
     </group>
 
@@ -162,15 +135,6 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-
-        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-          <arg name="input_radar_objects" value="radar_objects"/>
-          <arg name="input_radar_info" value="radar_info"/>
-          <arg name="output_detections" value="detected_objects"/>
-          <arg name="output_tracks" value="tracked_objects"/>
-          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-        </include>
-
       </group>
     </group>
 
@@ -195,15 +159,6 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-
-        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-          <arg name="input_radar_objects" value="radar_objects"/>
-          <arg name="input_radar_info" value="radar_info"/>
-          <arg name="output_detections" value="detected_objects"/>
-          <arg name="output_tracks" value="tracked_objects"/>
-          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-        </include>
-
       </group>
     </group>
 
@@ -228,15 +183,6 @@
           <arg name="configuration_host_port" value="42401"/>
           <arg name="configuration_sensor_port" value="42101"/>
         </include>
-
-        <include file="$(find-pkg-share autoware_radar_objects_adapter)/launch/radar_objects_adapter.launch.xml">
-          <arg name="input_radar_objects" value="radar_objects"/>
-          <arg name="input_radar_info" value="radar_info"/>
-          <arg name="output_detections" value="detected_objects"/>
-          <arg name="output_tracks" value="tracked_objects"/>
-          <arg name="param_path" value="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
-        </include>
-
       </group>
     </group>
 

--- a/aip_xx1_gen2_launch/launch/radar.launch.xml
+++ b/aip_xx1_gen2_launch/launch/radar.launch.xml
@@ -35,9 +35,27 @@
     <let name="acceleration_throttled_topic" value="$(var acceleration_topic)_throttled"/>
     <let name="steering_angle_throttled_topic" value="$(var steering_angle_topic)_throttled"/>
 
-    <node pkg="topic_tools" exec="throttle" name="odometry_throttler" output="screen" args="messages $(var odometry_topic) 25.0 $(var odometry_throttled_topic)"/>
-    <node pkg="topic_tools" exec="throttle" name="acceleration_throttler" output="screen" args="messages $(var acceleration_topic) 25.0 $(var acceleration_throttled_topic)"/>
-    <node pkg="topic_tools" exec="throttle" name="steering_angle_throttler" output="screen" args="messages $(var steering_angle_topic) 25.0 $(var steering_angle_throttled_topic)"/>
+    <!-- Component container for throttle nodes -->
+    <node_container pkg="rclcpp_components" exec="component_container" name="throttle_container" namespace="" output="screen">
+      <composable_node pkg="topic_tools" plugin="topic_tools::ThrottleNode" name="odometry_throttler">
+        <param name="input_topic" value="$(var odometry_topic)"/>
+        <param name="output_topic" value="$(var odometry_throttled_topic)"/>
+        <param name="throttle_type" value="messages"/>
+        <param name="msgs_per_sec" value="25.0"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::ThrottleNode" name="acceleration_throttler">
+        <param name="input_topic" value="$(var acceleration_topic)"/>
+        <param name="output_topic" value="$(var acceleration_throttled_topic)"/>
+        <param name="throttle_type" value="messages"/>
+        <param name="msgs_per_sec" value="25.0"/>
+      </composable_node>
+      <composable_node pkg="topic_tools" plugin="topic_tools::ThrottleNode" name="steering_angle_throttler">
+        <param name="input_topic" value="$(var steering_angle_topic)"/>
+        <param name="output_topic" value="$(var steering_angle_throttled_topic)"/>
+        <param name="throttle_type" value="messages"/>
+        <param name="msgs_per_sec" value="25.0"/>
+      </composable_node>
+    </node_container>
 
     <node pkg="topic_tools" exec="transform" name="steer_angle_transform" output="screen" args="/vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float32 'std_msgs.msg.Float32(data=m.steering_tire_angle)'  --import autoware_vehicle_msgs std_msgs --wait-for-start"/>
     <!-- ros2 run topic_tools transform /vehicle/status/steering_status /vehicle/status/steering_status_scalar std_msgs/msg/Float64 'std_msgs.msg.Float64(data=m.steering_tire_angle)'  \-\-import autoware_auto_vehicle_msgs std_msgs -->


### PR DESCRIPTION
As same as https://github.com/tier4/aip_launcher/pull/635


## Background
One cause of Pilot.Auto's long startup time is the exponential increase in discovery traffic due to the large number of ROS2 processes.
We are working to address this by reducing the process count through loading nodes into component containers.
[star4.slack.com/archives/CTEJP8L4T/p1761906077877939](https://star4.slack.com/archives/CTEJP8L4T/p1761906077877939)

## Changes
Unused adapter nodes are removed
Throttle nodes are launched in component container to reduce process.

## Test 
not yet