### PR TITLE
feat(aip_x2_gen2_launch): blind blockage status as a warning

### DIFF
--- a/aip_x2_gen2_launch/config/ARS548.param.yaml
+++ b/aip_x2_gen2_launch/config/ARS548.param.yaml
@@ -20,7 +20,7 @@
       blockage:
         status_level:
           ok: 2
-          warn: 1
+          warn: 0
         test_level:
           ok: 1
           warn: 1


### PR DESCRIPTION
Blockage diagnostics consists of:
- status level: by default `High` is warning, `Blind` is error.
```
'0': 'Blind'
'1': 'High'
'2': 'Mid'
'3': 'Low'
'4': 'None'
```
- test level: by default `Self test failed` is error.
```
'0': 'Self test failed'
'1': 'Self test passed'
'2': 'Self test ongoing'
```

This PR changes status level - `Blind` will be considered as warning (same as `High`).