### PR TITLE
Revert "shorten left_lower lidar range: Centerpoint left-side lost issue temporal measure #636"

### DIFF
--- a/aip_x2_gen2_launch/launch/lidar.launch.xml
+++ b/aip_x2_gen2_launch/launch/lidar.launch.xml
@@ -197,7 +197,7 @@
         <arg name="cloud_max_angle" value="270"/>
         <arg name="return_mode" value="LastStrongest"/>
         <arg name="min_range" value="0.1"/>
-        <arg name="max_range" value="12.0"/>
+        <arg name="max_range" value="50.0"/>
         <arg name="udp_only" value="$(var udp_only)"/>
         <arg name="launch_hw" value="$(var launch_driver)"/>
         <arg name="vehicle_mirror_param_file" value="$(var vehicle_mirror_param_file)"/>


### PR DESCRIPTION
Reverts tier4/aip_launcher#636
- As the root cause was investigated and cherry-pick PR was merged. 
- The discussion slack: https://star4.slack.com/archives/CRUE57C30/p1763529251586819?thread_ts=1762432186.406139&cid=CRUE57C30