### PR TITLE
fix(aip_x2_gen2_launch): relax visibility estimation parameters for fog detection

### DIFF
--- a/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
@@ -12,7 +12,7 @@
     visibility_estimation_max_azimuth_rad: 2.35           # Maximum azimuth for estimating point cloud visibility, in radius
     visibility_estimation_min_elevation_rad: -0.26        # Minimum elevation for estimating point cloud visibility, in radius
     visibility_estimation_max_elevation_rad: 1.04         # Maximum elevation for estimating point cloud visibility, in radius
-    visibility_estimation_max_secondary_voxel_count: 200  # Max number of secondary voxels to consider in visibility estimation
+    visibility_estimation_max_secondary_voxel_count: 115  # Max number of secondary voxels to consider in visibility estimation
     visibility_estimation_only: true                      # If true, only perform visibility estimation without filtering
     use_return_type_classification: true                  # Use return type information to classify points (e.g., primary/secondary returns)
     filter_secondary_returns: false                       # If true, filter out secondary returns and keep only primary returns
@@ -23,7 +23,7 @@
     filter_ratio_error_threshold: 0.5                     # Error threshold for filter ratio diagnostics
     filter_ratio_warn_threshold: 0.7                      # Warning threshold for filter ratio diagnostics
     visibility_error_threshold: 0.8                       # Error threshold for visibility diagnostics
-    num_frames_hysteresis_transition: 300                 # The number of frames to be required to transition judgement
+    num_frames_hysteresis_transition: 220                 # The number of frames to be required to transition judgement
     immediate_report_error: false                         # Whether to report error state immediately if a single frame categorized as error
     immediate_relax_state: false                          # Whether to relax state if observed state is better than the current one
     publish_area_marker: false                            # Publish a marker to visualize region used for visibility estimation


### PR DESCRIPTION
This PR relaxes the parameters to make the algorithm detect fog with a limited FoV

### Related links
- Issue ticket: [TIER IV INTERNAL](https://tier4.atlassian.net/browse/T4DEV-42477?search_id=3e205ac3-42ad-44f7-8136-6d7ad726ea73)
- The modification introduced by this PR has been confirmed for its validation on the evaluator
  - evaluator result: [TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/1a26fed7-f17b-5143-9db6-19103fca6ddc?project_id=x2_dev)
  - slack: [TIER IV INTERNAL](https://star4.slack.com/archives/C07K9RBUQR3/p1764578879608319?thread_ts=1764295900.329819&cid=C07K9RBUQR3)