### PR TITLE
feat: simple_object_merger node for radar from X2 Gen2

### DIFF
--- a/aip_x2_gen2_launch/launch/radar.launch.xml
+++ b/aip_x2_gen2_launch/launch/radar.launch.xml
@@ -179,13 +179,6 @@
       </include>
     </group>
 
-    <!-- merge radar objects -->
-    <let name="merger_param_path" value="$(find-pkg-share aip_x2_gen2_launch)/config/simple_object_merger.param.yaml"/>
-    <node pkg="autoware_simple_object_merger" exec="simple_object_merger_node" name="simple_object_merger" output="screen">
-      <remap from="~/output/objects" to="detected_objects"/>
-      <param from="$(var merger_param_path)"/>
-    </node>
-
     <let name="tracked_objects_merger_param_path" value="$(find-pkg-share aip_x2_gen2_launch)/config/simple_tracked_object_merger.param.yaml"/>
     <node pkg="autoware_simple_object_merger" exec="simple_tracked_object_merger_node" name="simple_tracked_object_merger" output="screen">
       <remap from="~/output/objects" to="tracked_objects"/>


### PR DESCRIPTION
# Description
This PR remove simple_object_merger node for radar from X2 Gen2 whose publishing topic has no subscriber.

# Test
lsim was launched with following command.
```
~/pilot-auto.x2$ ros2 launch autoware_launch logging_simulator.launch.xml vehicle_model:=j6_gen2 vehicle_id:=j6_gen2_01 sensor_model:=aip_x2_gen2 map_path:=$HOME/work/map/shiojiri_1211-20251125063151168045/ use_sim_time:=true rviz:=true
```

Then node diagram was checked.

**before**
<img width="2013" height="455" alt="image" src="https://github.com/user-attachments/assets/677fa35c-3fe0-426b-ae50-f44206c06bc0" />

**after**
<img width="1990" height="481" alt="image" src="https://github.com/user-attachments/assets/f636dbe5-4494-4e84-98cf-f5b5141c5d75" />


# Related links
https://star4.slack.com/archives/C076ZGRC15X/p1764585185861689