### PR TITLE
fix: add 'fintekcan' to ignoreWords in cspell configuration

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -119,5 +119,5 @@
     }
   ],
   "flagWords": [],
-  "ignoreWords": ["asterx", "ntrip", "NTRIP"]
+  "ignoreWords": ["asterx", "fintekcan", "ntrip", "NTRIP"]
 }


### PR DESCRIPTION
As the PR title suggests

ref: https://github.com/tier4/aip_launcher/pull/367