### PR TITLE
feat(aip_x2_gen2_launch): remove glog_component node from nebula launch

### DIFF
--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -134,16 +134,6 @@ def create_parameter_dict(*args):
     return result
 
 
-def make_common_nodes(context):
-    return [
-        ComposableNode(
-            package="autoware_glog_component",
-            plugin="autoware::glog_component::GlogComponent",
-            name="glog_component",
-        )
-    ]
-
-
 def make_nebula_node(context, as_composable_node, env=None):
     # Model and make
     sensor_model = LaunchConfiguration("sensor_model").perform(context)
@@ -585,7 +575,6 @@ def launch_setup(context, *args, **kwargs):
     if lidar_specific_container_nodes:
         container_package = "agnocastlib" if use_agnocast else "rclcpp_components"
 
-        lidar_specific_container_nodes.extend(make_common_nodes(context))
         lidar_specific_container = ComposableNodeContainer(
             name=LaunchConfiguration("container_name"),
             namespace="pointcloud_preprocessor",


### PR DESCRIPTION
# Descriptions
`glog_component` nodes launched in nebula_node_container.launch.py were for glog function. Therefore, these nodes can be removed safely because aip_launcher is used in pilot.auto and pilot.auto use forked rclcpp which adds glog function to all nodes and component containers.

Preliminary tests show that removing them reduces CPU usage on X2 by approximately 7%.
https://tier4.atlassian.net/wiki/spaces/XFST/pages/4784849060/glog_component+CPU

# Related Links
https://star4.slack.com/archives/C076E8EBJTG/p1767944478292439

# Tests Perfomed
Both of before and after change, following output is shown when killing pointcloud preprocessor process.
```
[component_container_mt-25] [INFO] [1768818766.093004925] [rclcpp]: signal_handler(signum=15)
[component_container_mt-25] *** Aborted at 1768818766 (unix time) try "date -d @1768818766" if you are using GNU date ***
[component_container_mt-25] PC: @                0x0 (unknown)
[component_container_mt-25] *** SIGTERM (@0x3e800017f38) received by PID 106859 (TID 0x7c627a33f680) from PID 98104; stack trace: ***
[component_container_mt-25]     @     0x7c627abec4d6 google::(anonymous namespace)::FailureSignalHandler()
[component_container_mt-25]     @     0x7c627aa19ded rclcpp::SignalHandler::signal_handler()
[component_container_mt-25]     @     0x7c627a042520 (unknown)
[component_container_mt-25]     @     0x7c627a0912c0 (unknown)
[component_container_mt-25]     @     0x7c627a098002 pthread_mutex_lock
[component_container_mt-25]     @     0x7c627a965374 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-25]     @     0x7c627a965808 rclcpp::executors::MultiThreadedExecutor::spin()
[component_container_mt-25]     @     0x62af9c89e771 main
[component_container_mt-25]     @     0x7c627a029d90 (unknown)
[component_container_mt-25]     @     0x7c627a029e40 __libc_start_main
[component_container_mt-25]     @     0x62af9c89ea95 _start
```

`ros2 node list` shows only glog_component nodes are different.
```sh
autoware@sub:/tmp$ diff -u before_without_transform.txt after_without_transform.txt 
--- before_without_transform.txt	2026-01-19 18:41:56.926396489 +0900
+++ after_without_transform.txt	2026-01-19 19:32:30.513199314 +0900
@@ -95,7 +95,7 @@
 /l4_toolkit/slip_detector
 /l4_toolkit/sudden_deceleration_monitor
 /l4_toolkit/vehicle_stuck_checker
-/launch_ros_100963
+/launch_ros_106772
 /localization/localization_error_monitor
 /localization/pose_estimator/ndt_scan_matcher
 /localization/pose_twist_fusion_filter/ekf_localizer
@@ -195,42 +195,34 @@
 /sensing/lidar/concatenate_data
 /sensing/lidar/front_lower/blockage_return_diag
 /sensing/lidar/front_lower/cuda_pointcloud_preprocessor_node
-/sensing/lidar/front_lower/glog_component
 /sensing/lidar/front_lower/hesai_ros_wrapper_node
 /sensing/lidar/front_lower/pointcloud_preprocessor/pointcloud_container
 /sensing/lidar/front_upper/blockage_return_diag
 /sensing/lidar/front_upper/cuda_pointcloud_preprocessor_node
-/sensing/lidar/front_upper/glog_component
 /sensing/lidar/front_upper/hesai_ros_wrapper_node
 /sensing/lidar/front_upper/pointcloud_preprocessor/pointcloud_container
 /sensing/lidar/left_lower/blockage_return_diag
 /sensing/lidar/left_lower/cuda_pointcloud_preprocessor_node
-/sensing/lidar/left_lower/glog_component
 /sensing/lidar/left_lower/hesai_ros_wrapper_node
 /sensing/lidar/left_lower/pointcloud_preprocessor/pointcloud_container
 /sensing/lidar/left_upper/blockage_return_diag
 /sensing/lidar/left_upper/cuda_pointcloud_preprocessor_node
-/sensing/lidar/left_upper/glog_component
 /sensing/lidar/left_upper/hesai_ros_wrapper_node
 /sensing/lidar/left_upper/pointcloud_preprocessor/pointcloud_container
 /sensing/lidar/rear_lower/blockage_return_diag
 /sensing/lidar/rear_lower/cuda_pointcloud_preprocessor_node
-/sensing/lidar/rear_lower/glog_component
 /sensing/lidar/rear_lower/hesai_ros_wrapper_node
 /sensing/lidar/rear_lower/pointcloud_preprocessor/pointcloud_container
 /sensing/lidar/rear_upper/blockage_return_diag
 /sensing/lidar/rear_upper/cuda_pointcloud_preprocessor_node
-/sensing/lidar/rear_upper/glog_component
 /sensing/lidar/rear_upper/hesai_ros_wrapper_node
 /sensing/lidar/rear_upper/pointcloud_preprocessor/pointcloud_container
 /sensing/lidar/right_lower/blockage_return_diag
 /sensing/lidar/right_lower/cuda_pointcloud_preprocessor_node
-/sensing/lidar/right_lower/glog_component
 /sensing/lidar/right_lower/hesai_ros_wrapper_node
 /sensing/lidar/right_lower/pointcloud_preprocessor/pointcloud_container
 /sensing/lidar/right_upper/blockage_return_diag
 /sensing/lidar/right_upper/cuda_pointcloud_preprocessor_node
-/sensing/lidar/right_upper/glog_component
 /sensing/lidar/right_upper/hesai_ros_wrapper_node
 /sensing/lidar/right_upper/pointcloud_preprocessor/pointcloud_container
 /sensing/lidar/right_upper/polar_voxel_outlier_filter
```