### PR TITLE
fix: visibility validation FOV

### DIFF
--- a/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
+++ b/aip_x2_gen2_launch/config/polar_voxel_outlier_filter_node.param.yaml
@@ -8,8 +8,8 @@
     min_radius_m: 0.5                                     # Minimum distance from the sensor to include points, in meters
     max_radius_m: 300.0                                   # Maximum distance from the sensor to include points, in meters
     visibility_estimation_max_range_m: 10.0               # Maximum range for estimating point cloud visibility, in meters
-    visibility_estimation_min_azimuth_rad: 0.78           # Minimum azimuth for estimating point cloud visibility, in radius
-    visibility_estimation_max_azimuth_rad: 2.35           # Maximum azimuth for estimating point cloud visibility, in radius
+    visibility_estimation_min_azimuth_rad: 1.047           # Minimum azimuth for estimating point cloud visibility, in radius
+    visibility_estimation_max_azimuth_rad: 2.093           # Maximum azimuth for estimating point cloud visibility, in radius
     visibility_estimation_min_elevation_rad: -0.26        # Minimum elevation for estimating point cloud visibility, in radius
     visibility_estimation_max_elevation_rad: 1.04         # Maximum elevation for estimating point cloud visibility, in radius
     visibility_estimation_max_secondary_voxel_count: 115  # Max number of secondary voxels to consider in visibility estimation


### PR DESCRIPTION
## Description
これまでは水平のFOVが 0.78rad (45deg) -- 2.35rad (135deg)だったが、下記チケットにて誤検知が出ているためFOVを狭めることによって対応する
1.047rad (60deg) -- 2.093rad (120deg)に変更する

## Related Links
https://tier4.atlassian.net/browse/T4DEV-33560

## Tests Perfomed
rosbagによる机上検証では誤検知は発生しなくなっている
https://github.com/user-attachments/assets/09b58ce4-d6c7-4b32-87fb-777a21ce691b

降雨試験データにてPASSを確認
https://evaluation.tier4.jp/evaluation/reports/ccfe2efa-0878-5006-8c9d-60dc7bc52126?project_id=x2_dev

