### PR TITLE
feat(aip_x2_gen2_launch): apply autoware_agnocast_wrapper for CIE

### DIFF
--- a/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
+++ b/aip_x2_gen2_launch/launch/nebula_node_container.launch.py
@@ -20,14 +20,15 @@ from math import sin
 from math import sqrt
 import os
 
+from ament_index_python.packages import get_package_share_directory
 import launch
 from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
 from launch.actions import OpaqueFunction
-from launch.actions import SetLaunchConfiguration
 
 # from launch.conditions import LaunchConfigurationNotEquals
 from launch.conditions import IfCondition
-from launch.conditions import UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
@@ -452,14 +453,6 @@ def make_blockage_diag_nodes(context):
     ]
 
 
-def make_agnocast_env(context):
-    agnocast_heaphook_path = LaunchConfiguration("agnocast_heaphook_path").perform(context)
-    return {
-        "LD_PRELOAD": f"{agnocast_heaphook_path}:{os.getenv('LD_PRELOAD', '')}",  # noqa: E231
-        "AGNOCAST_MEMPOOL_SIZE": "1073741824",  # 1GB
-    }
-
-
 def make_polar_voxel_outlier_filter_node(context):
     parameters = ParameterFile(
         LaunchConfiguration("polar_voxel_outlier_filter_node_param_file").perform(context),
@@ -512,7 +505,6 @@ def make_polar_voxel_outlier_filter_node(context):
 def launch_setup(context, *args, **kwargs):
     mode = LaunchConfiguration("pipeline_mode").perform(context)
     use_agnocast = os.getenv("ENABLE_AGNOCAST") == "1"
-    env = make_agnocast_env(context) if use_agnocast else {}
 
     use_blockage_diag = IfCondition(LaunchConfiguration("enable_blockage_diag")).evaluate(context)
 
@@ -523,23 +515,6 @@ def launch_setup(context, *args, **kwargs):
     shared_container_nodes = []
     lidar_specific_container_nodes = []
     standalone_nodes = []
-
-    container_exec = "agnocast_component_container" if use_agnocast else "component_container"
-    container_exec_mt = (
-        "agnocast_component_container_mt" if use_agnocast else "component_container_mt"
-    )
-
-    set_container_executable = SetLaunchConfiguration(
-        "container_executable",
-        container_exec,
-        condition=UnlessCondition(LaunchConfiguration("use_multithread")),
-    )
-
-    set_container_mt_executable = SetLaunchConfiguration(
-        "container_executable",
-        container_exec_mt,
-        condition=IfCondition(LaunchConfiguration("use_multithread")),
-    )
 
     match mode:
         case "cuda":
@@ -581,20 +556,21 @@ def launch_setup(context, *args, **kwargs):
         case _:
             raise ValueError(f"Unknown pipeline mode: {mode}")
 
-    launch_targets = [set_container_executable, set_container_mt_executable]
+    launch_targets = []
 
     if lidar_specific_container_nodes:
-        container_package = "agnocastlib" if use_agnocast else "rclcpp_components"
-
         lidar_specific_container_nodes.extend(make_common_nodes(context))
         lidar_specific_container = ComposableNodeContainer(
             name=LaunchConfiguration("container_name"),
             namespace="pointcloud_preprocessor",
-            package=container_package,
+            package=LaunchConfiguration("container_package"),
             executable=LaunchConfiguration("container_executable"),
             composable_node_descriptions=lidar_specific_container_nodes,
             output="both",
-            additional_env=env,
+            additional_env={
+                "LD_PRELOAD": LaunchConfiguration("ld_preload_value"),
+                "AGNOCAST_MEMPOOL_SIZE": "1073741824",
+            },
         )
         launch_targets.append(lidar_specific_container)
 
@@ -745,4 +721,20 @@ def generate_launch_description():
     add_launch_arg("hires_mode", "true")
     add_launch_arg("diagnostics.packet_loss.error_threshold")
 
-    return launch.LaunchDescription(launch_arguments + [OpaqueFunction(function=launch_setup)])
+    agnocast_env = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("autoware_agnocast_wrapper"),
+                "launch",
+                "agnocast_env.launch.py",
+            )
+        ),
+        launch_arguments=[
+            ("use_multithread", "true"),
+            ("agnocast_heaphook_path", LaunchConfiguration("agnocast_heaphook_path")),
+        ],
+    )
+
+    return launch.LaunchDescription(
+        launch_arguments + [agnocast_env, OpaqueFunction(function=launch_setup)]
+    )

--- a/aip_x2_gen2_launch/package.xml
+++ b/aip_x2_gen2_launch/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <exec_depend>aip_common_sensor_launch</exec_depend>
+  <exec_depend>autoware_agnocast_wrapper</exec_depend>
   <exec_depend>autoware_dummy_diag_publisher</exec_depend>
   <exec_depend>autoware_glog_component</exec_depend>
   <exec_depend>autoware_gnss_poser</exec_depend>


### PR DESCRIPTION
## Description

Apply `autoware_agnocast_wrapper` to enable `CallbackIsolatedAgnocastExecutor` (CIE) for this package, as part of the effort to achieve middleware-transparent scheduling and optimize end-to-end response time across Autoware. By going through `autoware_agnocast_wrapper`, CIE activation is controlled by the `ENABLE_AGNOCAST` environment variable — when unset or `0`, the node runs with the standard ROS 2 executor as before; when set to `1`, it switches to `CallbackIsolatedAgnocastExecutor`.

### Changes

- **`aip_x2_gen2_launch/launch/nebula_node_container.launch.py`**:
  - Replaced inline `make_agnocast_env()` and manual `SetLaunchConfiguration` logic for container executable/package selection with an `IncludeLaunchDescription` of `autoware_agnocast_wrapper`'s `agnocast_env.launch.py`, which provides `container_package`, `container_executable`, and `ld_preload_value` launch configurations based on the `ENABLE_AGNOCAST` environment variable.
  - The `ComposableNodeContainer` now uses `LaunchConfiguration("container_package")` and `LaunchConfiguration("container_executable")` from the included launch file, with `ld_preload_value` set in `additional_env`.
  - Removed `SetLaunchConfiguration` blocks and `make_agnocast_env` function.
- **`aip_x2_gen2_launch/package.xml`**: Added `autoware_agnocast_wrapper` as an `exec_depend`.

## Related links

- [AutowareDiscussion about adopting CIE](https://github.com/orgs/autowarefoundation/discussions/6813)
- [What is autoware_agnocast_wrapper?](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/README.md)

## How was this PR tested?

- Evaluator passed.
- Verification in Lsim (both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`).

## Notes for reviewers

**Please review the following aspects:**

- Verify that all relevant `CMakeLists.txt` and launch files in this package have been updated (no missed files).
- If the node meets **all** of the following conditions, please check for potential race conditions (see [Effects on system behavior](#effects-on-system-behavior) for the reason):
  1. The node was originally running on a `SingleThreadedExecutor`
  2. The node has multiple callback groups
  3. Shared variables are accessed across callback groups without proper mutex protection

## Interface changes

None.

## Effects on system behavior

When `ENABLE_AGNOCAST=0` (default), there is no change in behavior at all — the node runs with the standard ROS 2 executor exactly as before.

When `ENABLE_AGNOCAST=1`, the executor switches to `CallbackIsolatedAgnocastExecutor` (CIE). Internally, CIE creates a dedicated `rclcpp::SingleThreadedExecutor` for each callback group, so the fundamental scheduling behavior within each group remains almost identical. The key difference is that, for nodes originally using `SingleThreadedExecutor`, callback groups now run in parallel across separate threads, similar to `MultiThreadedExecutor`.