### PR TITLE
feat(cherry-pick): diasble some topic_state_monitor_node

### DIFF
--- a/aip_x2_gen2_launch/launch/topic_state_monitor.launch.py
+++ b/aip_x2_gen2_launch/launch/topic_state_monitor.launch.py
@@ -18,26 +18,6 @@ from launch_ros.descriptions import ComposableNode
 
 
 def generate_launch_description():
-    # GNSS topic monitor
-    gnss_topic_monitor = ComposableNode(
-        package="autoware_topic_state_monitor",
-        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_gnss_pose",
-        parameters=[
-            {
-                "topic": "/sensing/gnss/pose",
-                "topic_type": "geometry_msgs/msg/PoseStamped",
-                "best_effort": True,
-                "diag_name": "gnss_topic_status",
-                "warn_rate": 2.5,
-                "error_rate": 0.5,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
     # IMU topic monitor
     imu_topic_monitor = ComposableNode(
         package="autoware_topic_state_monitor",
@@ -58,136 +38,14 @@ def generate_launch_description():
         extra_arguments=[{"use_intra_process_comms": True}],
     )
 
-    # Radar topic monitors
-    radar_front_center_monitor = ComposableNode(
-        package="autoware_topic_state_monitor",
-        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_front_center",
-        parameters=[
-            {
-                "topic": "/sensing/radar/front_center/nebula_packets",
-                "topic_type": "nebula_msgs/msg/NebulaPackets",
-                "best_effort": True,
-                "diag_name": "radar_front_center_topic_status",
-                "warn_rate": 20.0,
-                "error_rate": 5.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_front_left_monitor = ComposableNode(
-        package="autoware_topic_state_monitor",
-        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_front_left",
-        parameters=[
-            {
-                "topic": "/sensing/radar/front_left/nebula_packets",
-                "topic_type": "nebula_msgs/msg/NebulaPackets",
-                "best_effort": True,
-                "diag_name": "radar_front_left_topic_status",
-                "warn_rate": 20.0,
-                "error_rate": 5.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_front_right_monitor = ComposableNode(
-        package="autoware_topic_state_monitor",
-        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_front_right",
-        parameters=[
-            {
-                "topic": "/sensing/radar/front_right/nebula_packets",
-                "topic_type": "nebula_msgs/msg/NebulaPackets",
-                "best_effort": True,
-                "diag_name": "radar_front_right_topic_status",
-                "warn_rate": 20.0,
-                "error_rate": 5.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_rear_center_monitor = ComposableNode(
-        package="autoware_topic_state_monitor",
-        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_rear_center",
-        parameters=[
-            {
-                "topic": "/sensing/radar/rear_center/nebula_packets",
-                "topic_type": "nebula_msgs/msg/NebulaPackets",
-                "best_effort": True,
-                "diag_name": "radar_rear_center_topic_status",
-                "warn_rate": 20.0,
-                "error_rate": 5.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_rear_left_monitor = ComposableNode(
-        package="autoware_topic_state_monitor",
-        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_rear_left",
-        parameters=[
-            {
-                "topic": "/sensing/radar/rear_left/nebula_packets",
-                "topic_type": "nebula_msgs/msg/NebulaPackets",
-                "best_effort": True,
-                "diag_name": "radar_rear_left_topic_status",
-                "warn_rate": 20.0,
-                "error_rate": 5.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    radar_rear_right_monitor = ComposableNode(
-        package="autoware_topic_state_monitor",
-        plugin="autoware::topic_state_monitor::TopicStateMonitorNode",
-        name="topic_state_monitor_radar_rear_right",
-        parameters=[
-            {
-                "topic": "/sensing/radar/rear_right/nebula_packets",
-                "topic_type": "nebula_msgs/msg/NebulaPackets",
-                "best_effort": True,
-                "diag_name": "radar_rear_right_topic_status",
-                "warn_rate": 20.0,
-                "error_rate": 5.0,
-                "timeout": 5.0,
-                "window_size": 10,
-            }
-        ],
-        extra_arguments=[{"use_intra_process_comms": True}],
-    )
-
-    # ComposableNodeContainer to run all ComposableNodes
+    # ComposableNodeContainer to run enabled ComposableNodes
     container = ComposableNodeContainer(
         name="topic_state_monitor_container",
         namespace="topic_state_monitor",
         package="rclcpp_components",
         executable="component_container",
         composable_node_descriptions=[
-            gnss_topic_monitor,
             imu_topic_monitor,
-            radar_front_center_monitor,
-            radar_front_left_monitor,
-            radar_front_right_monitor,
-            radar_rear_center_monitor,
-            radar_rear_left_monitor,
-            radar_rear_right_monitor,
         ],
         output="screen",
     )


### PR DESCRIPTION
## Description

cherry pick for experiment. no awf merged PRs

## Notes

- To improve the `/diagnostics` transmission cycle, this change must be applied in conjunction with the following cherry-pick PR.
  - https://github.com/tier4/autoware_universe/pull/2840
  - https://github.com/tier4/autoware_launch.x2/pull/2107
  - https://github.com/tier4/aip_launcher/pull/682
  - https://github.com/tier4/autoware_core/pull/91

## How was this PR tested?

### 1. `/diagnostics` Transmission Frequency

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Mean Hz | 1,216 Hz | 855 Hz | −30% |
| Std Hz | 171 Hz | 115 Hz | −33% |
| Max Hz | 1,278 Hz | 884 Hz | −31% |

**Analysis:** The transmission frequency decreased by approximately 30%, and variance was reduced. This indicates a lighter input load on the diagnostics pipeline.

---

### 2. Total CPU Utilization

> Combined load of multiple `topic_state_monitor` instances + `aggregator_node`

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Mean | 47.7% | 33.0% | −14.7 pt (−31%) |
| P50 (Median) | 52.0% | 34.0% | −18.0 pt (−35%) |
| P95 | 62.0% | 44.0% | −18.0 pt (−29%) |
| Max | 70.0% | 50.0% | −20.0 pt (−29%) |
| Std | 13.8% | 8.4% | −39% (Improved Stability) |

**Analysis:** CPU usage was reduced by approximately 30% in both mean and median values. The standard deviation also decreased by about 40%, effectively suppressing load fluctuations.

---

## Overall Summary

The reduction in `/diagnostics` transmission frequency (~30%) is almost directly proportional to the reduction in CPU usage (~30%). This confirms that the high transmission frequency was the primary cause of the CPU load.