### PR TITLE
feat(gyro_scale_estimator): enable online IMU calibration

### DIFF
--- a/aip_x2_gen2_launch/config/gyro_scale_estimator.param.yaml
+++ b/aip_x2_gen2_launch/config/gyro_scale_estimator.param.yaml
@@ -40,6 +40,6 @@
       drift_bias: 0.0
 
     on_off_correction:
-      correct_for_static_bias: true
-      correct_for_dynamic_bias: false
-      correct_for_scale: false
+      correct_for_static_bias: false
+      correct_for_dynamic_bias: true
+      correct_for_scale: true


### PR DESCRIPTION
Diffusion Plannerデータ取得用に動的IMUキャリブレーションをONにします。
PDDのsergioさん、yoshi.riさん、薮内さんに確認済みです。


関連スレ: https://star4.slack.com/archives/CRUE57C30/p1776411197957659
参考PR: https://github.com/tier4/aip_launcher/pull/677