### PR TITLE
feat: add login for septentrio gnss (cherry-pick #12 from aip_launcher.epalette)

### DIFF
--- a/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
+++ b/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
@@ -142,3 +142,7 @@
         # For GNSS Rx only
         gpgsa: false
         gpgsv: false
+
+    loging:
+      user: "GnssUser"
+      password: "gnss.user"

--- a/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
+++ b/aip_x2_gen2_launch/config/asterx_sb3_rover.param.yaml
@@ -143,6 +143,6 @@
         gpgsa: false
         gpgsv: false
 
-    loging:
+    login:
       user: "GnssUser"
       password: "gnss.user"


### PR DESCRIPTION
## Summary

- Cherry-pick https://github.com/tier4/aip_launcher.epalette/pull/12 into `beta/x2/v4.3.1.2`

:warning: マージ後、pilot-auto.x2 v4.3.1.2-hotfixのhashを要更新

## Description

GNSSのFW versionによっては起動時にログインを要求されるため、ログインパラメータを追加

```
May 25 16:37:55 main autoware_main_launch[39941]: [septentrio_gnss_driver_node-20] [ERROR 1779694668.753988827] [sensing.gnss.septentrio] log(): "Invalid command just sent to the Rx! The Rx's response contains 88 bytes and reads:
May 25 16:37:55 main autoware_main_launch[39941]: [septentrio_gnss_driver_node-20]  $R? setSBFOutput: Not authorized! Please use the "login" command to get authorization.
```

benchの旧FW versionでも問題ないこと確認
```
ros2 topic echo /sensing/gnss/septentrio/nav_sat_fix
header:
  stamp:
    sec: 1781827172
    nanosec: 406050075
  frame_id: top_rear/gnss_link
status:
  status: 0
  service: 15
latitude: 35.62429338661215
longitude: 139.74256450019368
altitude: 57.03631062354839
position_covariance:
- 685.114013671875
- -427.9282531738281
- -955.79052734375
- -427.9282531738281
- 2740.521728515625
- 4095.030029296875
- -955.79052734375
- 4095.030029296875
- 10437.9541015625
position_covariance_type: 3

```