### PR TITLE
ci(pre-commit): update hooks and remove flake8-ros from pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,9 @@ ci:
   autofix_commit_msg: "ci(pre-commit): autofix"
   autoupdate_commit_msg: "ci(pre-commit): autoupdate"
 
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,9 @@
 ci:
-  autofix_commit_msg: "ci(pre-commit): autofix"
-  autoupdate_commit_msg: "ci(pre-commit): autoupdate"
-
-default_language_version:
-  python: python3.12
+  autofix_commit_msg: "style(pre-commit): autofix"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -21,48 +17,35 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
+    rev: v0.41.0
     hooks:
       - id: markdownlint
         args: [-c, .markdownlint.yaml, --fix]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.29.0
+    rev: v1.35.1
     hooks:
       - id: yamllint
 
-  - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.8.0
-    hooks:
-      - id: flake8-ros
-      - id: prettier-package-xml
-      - id: sort-package-xml
-
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.2
+    rev: v0.10.0.1
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.6.0-1
+    rev: v3.8.0-1
     hooks:
       - id: shfmt
         args: [-w, -s, -i=4]
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  - repo: https://github.com/AleksaC/hadolint-py
+    rev: v2.14.0
     hooks:
-      - id: isort
-
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-      - id: black
-        args: [--line-length=100]
+      - id: hadolint
 
 exclude: .svg

--- a/aip_urdf_compiler/readme.md
+++ b/aip_urdf_compiler/readme.md
@@ -30,7 +30,6 @@ To use aip_urdf_compiler in your description package:
   ```
 
 - Configure your sensors in `config/sensors.yaml` with metadata values (Note: do not need to add meta values in `individual_params`):
-
   - `type`: Required string, corresponding to the string value from [existing sensors](#existing-sensors)
   - `frame_id`: Optional string, overwrites the TF frame ID.
 
@@ -67,13 +66,11 @@ class LinkType(enum.Enum):
 ### Components
 
 1. **aip_urdf_compiler**
-
    - Main package handling URDF generation
    - Processes configuration files
    - Manages build-time compilation
 
 2. **aip_cmake_urdf_compile**
-
    - CMake macro implementation
    - Creates build targets
    - Ensures URDF regeneration on each build
@@ -86,13 +83,11 @@ class LinkType(enum.Enum):
 ### Compilation Process
 
 1. **Configuration Reading**
-
    - Parses `config/sensors.yaml`
    - Extracts transformation data
    - Validates configurations
 
 2. **Transform Processing**
-
    - Processes each sensor transform
    - Determines sensor types and frame IDs
    - Generates appropriate macro strings
@@ -106,7 +101,6 @@ class LinkType(enum.Enum):
 ## Adding New Sensors
 
 1. Add sensor descriptions (xacro module files) in either:
-
    - Your target package
    - `common_sensor_description` package
 
@@ -127,7 +121,6 @@ cat $workspace/log/build_<timestamp>/aip_{project}_description/streams.log
 ### Common Issues
 
 1. Missing sensor definitions
-
    - Ensure sensor type is defined in `LinkType`
    - Verify xacro file exists in description package
 

--- a/aip_urdf_compiler/readme.md
+++ b/aip_urdf_compiler/readme.md
@@ -30,6 +30,7 @@ To use aip_urdf_compiler in your description package:
   ```
 
 - Configure your sensors in `config/sensors.yaml` with metadata values (Note: do not need to add meta values in `individual_params`):
+
   - `type`: Required string, corresponding to the string value from [existing sensors](#existing-sensors)
   - `frame_id`: Optional string, overwrites the TF frame ID.
 
@@ -66,11 +67,13 @@ class LinkType(enum.Enum):
 ### Components
 
 1. **aip_urdf_compiler**
+
    - Main package handling URDF generation
    - Processes configuration files
    - Manages build-time compilation
 
 2. **aip_cmake_urdf_compile**
+
    - CMake macro implementation
    - Creates build targets
    - Ensures URDF regeneration on each build
@@ -83,11 +86,13 @@ class LinkType(enum.Enum):
 ### Compilation Process
 
 1. **Configuration Reading**
+
    - Parses `config/sensors.yaml`
    - Extracts transformation data
    - Validates configurations
 
 2. **Transform Processing**
+
    - Processes each sensor transform
    - Determines sensor types and frame IDs
    - Generates appropriate macro strings
@@ -101,6 +106,7 @@ class LinkType(enum.Enum):
 ## Adding New Sensors
 
 1. Add sensor descriptions (xacro module files) in either:
+
    - Your target package
    - `common_sensor_description` package
 
@@ -121,6 +127,7 @@ cat $workspace/log/build_<timestamp>/aip_{project}_description/streams.log
 ### Common Issues
 
 1. Missing sensor definitions
+
    - Ensure sensor type is defined in `LinkType`
    - Verify xacro file exists in description package
 


### PR DESCRIPTION
## Summary
pre-commit.ci が Python 3.14 ランナーで失敗する問題を、hook の更新と `flake8-ros` 削除で解消します。

## Background
- pre-commit.ci runner image `2026-05-29` 以降、Python 3.14 がデフォルト
- 既存の `flake8-ros`（flake8 6.x / pyflakes）は Python 3.14 非互換でクラッシュ
- Python バージョン固定ではなく、pre-commit.ci 側の hook 構成を見直す方針

## Changes
- `.pre-commit-config.yaml` を更新
  - 各 hook のバージョンを更新
  - `flake8-ros` / `black` / `isort` / ROS 向け XML 整形 hook を削除
  - `hadolint` を追加
  - `autofix_commit_msg` を `style(pre-commit): autofix` に変更

## Notes

## Test plan
- [ ] pre-commit.ci - pr が pass すること
- [ ] pre-commit-optional が pass すること
