### PR TITLE
feat(xx1_gen2): add ioniq5 lidar path

### DIFF
--- a/aip_xx1_gen2_launch/config/lidar_gen2_ioniq5.yaml
+++ b/aip_xx1_gen2_launch/config/lidar_gen2_ioniq5.yaml
@@ -52,14 +52,14 @@ launches:
       cut_angle: 270.0
       cloud_min_angle: 90
       cloud_max_angle: 270
-  - sensor_type: hesai_XT32
-    namespace: rear
-    parameters:
-      max_range: 1.5
-      sensor_frame: hesai_rear
-      sensor_ip: 192.168.1.25
-      data_port: 2373
-      sync_angle: 270
-      cut_angle: 270.0
-      cloud_min_angle: 90
-      cloud_max_angle: 270
+  # - sensor_type: hesai_XT32
+  #   namespace: rear
+  #   parameters:
+  #     max_range: 1.5
+  #     sensor_frame: hesai_rear
+  #     sensor_ip: 192.168.1.25
+  #     data_port: 2373
+  #     sync_angle: 270
+  #     cut_angle: 270.0
+  #     cloud_min_angle: 90
+  #     cloud_max_angle: 270

--- a/aip_xx1_gen2_launch/config/lidar_gen2_ioniq5.yaml
+++ b/aip_xx1_gen2_launch/config/lidar_gen2_ioniq5.yaml
@@ -1,0 +1,65 @@
+launches:
+  - sensor_type: hesai_OT128
+    namespace: top
+    parameters:
+      max_range: 300.0
+      sensor_frame: hesai_top
+      sensor_ip: 192.168.1.201
+      data_port: 2368
+      sync_angle: 90
+      cut_angle: 90.0
+  # - sensor_type: hesai_XT32
+  #   namespace: front_left
+  #   parameters:
+  #     max_range: 80.0
+  #     sensor_frame: hesai_front_left
+  #     sensor_ip: 192.168.1.21
+  #     data_port: 2369
+  #     sync_angle: 50
+  #     cut_angle: 320.0
+  #     cloud_min_angle: 50
+  #     cloud_max_angle: 320
+  # - sensor_type: hesai_XT32
+  #   namespace: front_right
+  #   parameters:
+  #     max_range: 80.0
+  #     sensor_frame: hesai_front_right
+  #     sensor_ip: 192.168.1.22
+  #     data_port: 2370
+  #     sync_angle: 310
+  #     cut_angle: 310.0
+  #     cloud_min_angle: 40
+  #     cloud_max_angle: 310
+  - sensor_type: hesai_XT32
+    namespace: side_left
+    parameters:
+      max_range: 10.0
+      sensor_frame: hesai_side_left
+      sensor_ip: 192.168.1.23
+      data_port: 2371
+      sync_angle: 90
+      cut_angle: 270.0
+      cloud_min_angle: 90
+      cloud_max_angle: 270
+  - sensor_type: hesai_XT32
+    namespace: side_right
+    parameters:
+      max_range: 10.0
+      sensor_frame: hesai_side_right
+      sensor_ip: 192.168.1.24
+      data_port: 2372
+      sync_angle: 270
+      cut_angle: 270.0
+      cloud_min_angle: 90
+      cloud_max_angle: 270
+  - sensor_type: hesai_XT32
+    namespace: rear
+    parameters:
+      max_range: 1.5
+      sensor_frame: hesai_rear
+      sensor_ip: 192.168.1.25
+      data_port: 2373
+      sync_angle: 270
+      cut_angle: 270.0
+      cloud_min_angle: 90
+      cloud_max_angle: 270

--- a/aip_xx1_gen2_launch/launch/sensing.launch.xml
+++ b/aip_xx1_gen2_launch/launch/sensing.launch.xml
@@ -4,7 +4,6 @@
   <arg name="vehicle_mirror_param_file" description="path to the file of vehicle mirror position yaml"/>
   <arg name="perception_mode" default="camera_lidar_fusion" description="select perception mode. camera_lidar_fusion, lidar, camera"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
-  <arg name="vehicle_id" default="$(env VEHICLE_ID default)" />
   <arg name="vehicle_model" default="$(env VEHICLE_MODEL default)"/>
 
   <group>

--- a/aip_xx1_gen2_launch/launch/sensing.launch.xml
+++ b/aip_xx1_gen2_launch/launch/sensing.launch.xml
@@ -4,7 +4,8 @@
   <arg name="vehicle_mirror_param_file" description="path to the file of vehicle mirror position yaml"/>
   <arg name="perception_mode" default="camera_lidar_fusion" description="select perception mode. camera_lidar_fusion, lidar, camera"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
-  <arg name ="vehicle_id" default="$(env VEHICLE_ID default)" />
+  <arg name="vehicle_id" default="$(env VEHICLE_ID default)" />
+  <arg name="vehicle_model" default="$(env VEHICLE_MODEL default)"/>
 
   <group>
 
@@ -12,6 +13,7 @@
     <let name="is_gen2_0" value="$(eval &quot;'$(var vehicle_id)' in ['1', '5', '8']&quot;)"/>
     <let name="lidar_config_file" value="$(find-pkg-share aip_xx1_gen2_launch)/config/lidar_gen2.yaml" if="$(var is_gen2_0)"/>
     <let name="lidar_config_file" value="$(find-pkg-share aip_xx1_gen2_launch)/config/lidar_gen2_1.yaml" unless="$(var is_gen2_0)"/>
+    <let name="lidar_config_file" value="$(find-pkg-share aip_xx1_gen2_launch)/config/lidar_gen2_ioniq5.yaml" if="$(eval &quot;'$(var vehicle_model)' == 'ioniq5'&quot;)"/>
     <log message="lidar_config_file: $(var lidar_config_file)"/>
 
     <include file="$(find-pkg-share aip_xx1_gen2_launch)/launch/lidar.launch.py">

--- a/aip_xx1_gen2_launch/launch/sensing.launch.xml
+++ b/aip_xx1_gen2_launch/launch/sensing.launch.xml
@@ -4,7 +4,6 @@
   <arg name="vehicle_mirror_param_file" description="path to the file of vehicle mirror position yaml"/>
   <arg name="perception_mode" default="camera_lidar_fusion" description="select perception mode. camera_lidar_fusion, lidar, camera"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
-  <arg name="vehicle_model" default="$(env VEHICLE_MODEL default)"/>
 
   <group>
 


### PR DESCRIPTION
## Description
ioniq5用のlidar分岐を作成しました。
ioniq5ではfront left/rightがないのでそれらを見ないようにします。
rearに関しては以下のもので削除されます。
https://github.com/tier4/autoware_launch.xx1/blob/tier4/main/aip_launcher/aip_xx1_gen2_launch/launch/lidar.launch.py#L96-L102

参考：[https://app.diagrams.net/#G1bqXIg6xBzAxTdmcwebQdw6nO0U9aCYaL#{"pageId"%3A"hF0MPtWqjfvqvMuOM7mS"}](https://app.diagrams.net/#G1bqXIg6xBzAxTdmcwebQdw6nO0U9aCYaL#%7B%22pageId%22%3A%22hF0MPtWqjfvqvMuOM7mS%22%7D)

オレンジの取り付け角度の位置がコネクタの位置です。
ioniq5ではオレンジの位置が車両正面に対して右にあるのでsync/cut angleは90度です。

## How was this PR tested?

ローカルでテストし、配線が正しいことを確認しました。
実車でも同様のyamlで問題ないことを確認しました。

## Notes for reviewers

None.

## Effects on system behavior

None.
